### PR TITLE
Implement and style shadcn ui sidebar

### DIFF
--- a/src/core/layouts/DashboardLayout.tsx
+++ b/src/core/layouts/DashboardLayout.tsx
@@ -27,7 +27,7 @@ export default function DashboardLayout({ children }: { children?: React.ReactNo
   return (
     <div className="min-h-dvh grid grid-rows-[auto_1fr] bg-background text-foreground">
       {/* Header */}
-      <header className="sticky top-0 z-10 border-b bg-background/80 backdrop-blur">
+      <header className="sticky top-0 z-10 border-b bg-background/80 backdrop-blur border-border">
         <div className="container mx-auto flex items-center gap-3 p-3">
           {/* Mobile menu trigger */}
           <div className="lg:hidden">
@@ -37,8 +37,8 @@ export default function DashboardLayout({ children }: { children?: React.ReactNo
                   <Menu className="size-4" />
                 </Button>
               </SheetTrigger>
-              <SheetContent side={sheetSide} className="w-72 p-0">
-                <div className="p-4 border-b">
+              <SheetContent side={sheetSide} className="w-72 p-0 bg-sidebar text-sidebar-foreground border-sidebar-border">
+                <div className="p-4 border-b border-sidebar-border">
                   <SheetHeader>
                     <SheetTitle>{t("appTitle")}</SheetTitle>
                   </SheetHeader>
@@ -75,8 +75,8 @@ export default function DashboardLayout({ children }: { children?: React.ReactNo
       {/* Body */}
       <div className="grid grid-cols-1 lg:grid-cols-[240px_1fr] min-h-0">
         {/* Static sidebar (desktop) */}
-        <aside className="hidden lg:flex lg:flex-col border-e">
-          <div className="p-4 border-b font-bold">{t("appTitle")}</div>
+        <aside className="hidden lg:flex lg:flex-col border-e border-sidebar-border bg-sidebar text-sidebar-foreground">
+          <div className="p-4 border-b border-sidebar-border font-bold">{t("appTitle")}</div>
           <ScrollArea className="flex-1 p-4">
             <SidebarNav />
           </ScrollArea>

--- a/src/core/layouts/SidebarNav.tsx
+++ b/src/core/layouts/SidebarNav.tsx
@@ -32,7 +32,7 @@ export default function SidebarNav() {
             key={to}
             asChild
             variant={active ? "secondary" : "ghost"}
-            className="justify-start gap-2"
+            className="justify-start gap-2 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
           >
             <Link to={to}>
               <Icon className="size-4" />

--- a/src/design-system/tokens.css
+++ b/src/design-system/tokens.css
@@ -31,6 +31,16 @@
     --color-destructive-foreground: var(--destructive-foreground);
     --color-info: var(--info);
     --color-info-foreground: var(--info-foreground);
+
+    /* sidebar palette */
+    --color-sidebar: var(--sidebar);
+    --color-sidebar-foreground: var(--sidebar-foreground);
+    --color-sidebar-primary: var(--sidebar-primary);
+    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+    --color-sidebar-accent: var(--sidebar-accent);
+    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+    --color-sidebar-border: var(--sidebar-border);
+    --color-sidebar-ring: var(--sidebar-ring);
 }
 
 /* Light */
@@ -68,6 +78,19 @@
     --destructive-foreground: oklch(0.12 0 0);
     --info: oklch(0.86 0.09 210);
     --info-foreground: oklch(0.18 0.03 210);
+
+    /* sidebar (light) */
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
+
+    /* compatibility aliases (optional) */
+    --sidebar-background: 0 0% 98%;
 }
 
 /* Dark */
@@ -98,6 +121,19 @@
     --destructive-foreground: oklch(0.98 0 0);
     --info: oklch(0.70 0.10 210);
     --info-foreground: oklch(0.12 0.02 210);
+
+    /* sidebar (dark) */
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.439 0 0);
+
+    /* compatibility aliases (optional) */
+    --sidebar-background: 240 5.9% 10%;
 }
 
 /* component classes (اختیاری و مفید) */


### PR DESCRIPTION
Implement shadcn/ui sidebar theming and mock items.

Added sidebar color tokens to `src/design-system/tokens.css` and applied them to `DashboardLayout.tsx` and `SidebarNav.tsx` to align the sidebar's appearance with shadcn/ui patterns and set up mock items.

---
<a href="https://cursor.com/background-agent?bcId=bc-508b8fd8-e3c8-4c68-a23b-f3c021c20520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-508b8fd8-e3c8-4c68-a23b-f3c021c20520">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

