### PR TITLE
Configure project for shadcn ui sidebar

### DIFF
--- a/src/core/layouts/AppSidebar.tsx
+++ b/src/core/layouts/AppSidebar.tsx
@@ -49,7 +49,7 @@ export default function AppSidebar() {
   const side: "left" | "right" = locale === "fa" ? "right" : "left";
 
   return (
-    <Sidebar side={side} collapsible="icon">
+    <Sidebar side={side} collapsible="icon" variant="inset">
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/src/core/layouts/DashboardLayout.tsx
+++ b/src/core/layouts/DashboardLayout.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/shared/components/ui/input";
 
 import AppSidebar from "./AppSidebar";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import { SidebarInset } from "@/components/ui/sidebar";
 
 export default function DashboardLayout({ children }: { children?: React.ReactNode }) {
   const { t, locale } = useI18n();
@@ -22,7 +23,7 @@ export default function DashboardLayout({ children }: { children?: React.ReactNo
     <SidebarProvider>
       <AppSidebar />
 
-      <div className="min-h-dvh flex flex-col bg-background text-foreground">
+      <SidebarInset>
         {/* Header */}
         <header className="sticky top-0 z-10 border-b bg-background/80 backdrop-blur border-border">
           <div className="container mx-auto flex items-center gap-3 p-3">
@@ -56,7 +57,7 @@ export default function DashboardLayout({ children }: { children?: React.ReactNo
           <Outlet />
           {children}
         </main>
-      </div>
+      </SidebarInset>
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
Configure shadcn/ui for Vite and redesign the sidebar to match the 'inset' variant from the official documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-10d57c5f-d402-4b14-ab53-0e9142c9b507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10d57c5f-d402-4b14-ab53-0e9142c9b507">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

