### PR TITLE
Align sidebar based on language

### DIFF
--- a/src/core/layouts/AppSidebar.tsx
+++ b/src/core/layouts/AppSidebar.tsx
@@ -27,6 +27,7 @@ import {
     CollapsibleContent,
     CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { useI18n } from "@/shared/hooks/useI18n";
 
 // Menu items + children
 const items = [
@@ -83,8 +84,10 @@ const items = [
 ]
 
 export function AppSidebar() {
+    const { locale } = useI18n();
+    const side = locale === "fa" ? "right" : "left";
     return (
-        <Sidebar collapsible="icon">
+        <Sidebar collapsible="icon" side={side}>
             <SidebarContent>
                 <SidebarGroup>
                     <SidebarGroupLabel>Stores</SidebarGroupLabel>

--- a/src/core/sidebar/components/app-sidebar.tsx
+++ b/src/core/sidebar/components/app-sidebar.tsx
@@ -29,6 +29,7 @@ import {
     CollapsibleContent,
     CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { useI18n } from "@/shared/hooks/useI18n";
 
 // Menu items + children (ساب‌منوها)
 const items = [
@@ -85,8 +86,10 @@ const items = [
 ]
 
 export function AppSidebar() {
+    const { locale } = useI18n();
+    const side = locale === "fa" ? "right" : "left";
     return (
-        <Sidebar collapsible="icon">
+        <Sidebar collapsible="icon" side={side}>
             <SidebarContent>
                 <SidebarGroup>
                     <SidebarGroupLabel>Stores</SidebarGroupLabel>


### PR DESCRIPTION
Dynamically aligns the sidebar to left or right based on the current language locale.

This change enables the sidebar to correctly position itself for Right-to-Left (RTL) languages like Persian (fa) and Left-to-Right (LTR) languages like English (en), as requested by the user, without altering its visual design.

---
<a href="https://cursor.com/background-agent?bcId=bc-32a16683-8bfe-4986-8c15-c8639fa0564a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32a16683-8bfe-4986-8c15-c8639fa0564a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

