### PR TITLE
Fix inconsistent number display in Persian

### DIFF
--- a/src/features/brands/components/layout/Table/BrandsTable.tsx
+++ b/src/features/brands/components/layout/Table/BrandsTable.tsx
@@ -18,6 +18,7 @@ import {
 import { useI18n } from "@/shared/hooks/useI18n.ts";
 import { toAbsoluteUrl } from "@/shared/api/files.ts";
 import type { BrandData } from "@/features/brands/model/types.ts";
+import { convertDigitsByLocale } from "@/shared/i18n/numbers.ts";
 
 type Props = Readonly<{
     items: ReadonlyArray<BrandData>;
@@ -29,7 +30,7 @@ type Props = Readonly<{
 export default function BrandsTable({
                                         items, onDelete, onUndoDelete, showUndoInline = false,
                                     }: Props): JSX.Element {
-    const { t } = useI18n();
+    const { t, locale } = useI18n();
     const navigate = useNavigate();
 
     const goDetail = React.useCallback(
@@ -105,11 +106,11 @@ export default function BrandsTable({
                                 </TableCell>
 
                                 <TableCell className="max-w-[18rem] px-3 py-2.5 font-medium lg:max-w-[24rem] lg:px-4">
-                                    <span className="block truncate">{b.name}</span>
+                                    <span className="block truncate">{convertDigitsByLocale(b.name, locale)}</span>
                                 </TableCell>
 
                                 <TableCell className="w-40 px-3 py-2.5 lg:px-4">
-                                    {b.country ?? "-"}
+                                    {convertDigitsByLocale(b.country ?? "-", locale)}
                                 </TableCell>
 
                                 <TableCell className="px-3 py-2.5 lg:px-4">
@@ -120,9 +121,9 @@ export default function BrandsTable({
                                             rel="noopener noreferrer external"
                                             className="block max-w-[22ch] truncate underline-offset-4 hover:underline"
                                             onClick={(e) => e.stopPropagation()}
-                                            title={b.website}
+                                            title={convertDigitsByLocale(b.website, locale)}
                                         >
-                                            {b.website}
+                                            {convertDigitsByLocale(b.website, locale)}
                                         </a>
                                     ) : ("-")}
                                 </TableCell>

--- a/src/features/brands/components/layout/Table/BrandsTableRow.tsx
+++ b/src/features/brands/components/layout/Table/BrandsTableRow.tsx
@@ -10,11 +10,12 @@ import {
     DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import type { BrandData } from "@/features/brands/model/types";
+import { convertDigitsByLocale } from "@/shared/i18n/numbers";
 
 type Props = { brand: BrandData; onDelete: (id: string) => void; };
 
 export default function BrandsTableRow({ brand, onDelete }: Props) {
-    const { t } = useI18n();
+    const { t, locale } = useI18n();
     const navigate = useNavigate();
 
     const goDetail = () => navigate(ROUTES.BRAND.DETAIL(brand.id));
@@ -42,8 +43,8 @@ export default function BrandsTableRow({ brand, onDelete }: Props) {
                 ) : <div className="h-10 w-10 rounded bg-muted" onClick={(e)=>e.stopPropagation()} />}
             </TableCell>
 
-            <TableCell className="font-medium">{brand.name}</TableCell>
-            <TableCell>{brand.country ?? "-"}</TableCell>
+            <TableCell className="font-medium">{convertDigitsByLocale(brand.name, locale)}</TableCell>
+            <TableCell>{convertDigitsByLocale(brand.country ?? "-", locale)}</TableCell>
             <TableCell>
                 {brand.website ? (
                     <a
@@ -52,8 +53,9 @@ export default function BrandsTableRow({ brand, onDelete }: Props) {
                         rel="noopener noreferrer external"
                         className="text-primary underline underline-offset-2"
                         onClick={(e) => e.stopPropagation()}
+                        title={convertDigitsByLocale(brand.website, locale)}
                     >
-                        {brand.website}
+                        {convertDigitsByLocale(brand.website, locale)}
                     </a>
                 ) : ("-")}
             </TableCell>

--- a/src/features/brands/components/ui/Pagination.tsx
+++ b/src/features/brands/components/ui/Pagination.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react"
+import { useI18n } from "@/shared/hooks/useI18n"
+import { convertDigitsByLocale } from "@/shared/i18n/numbers"
 
 export type PaginationProps = {
     page: number
@@ -57,6 +59,8 @@ export default function Pagination({
                                        onPageSizeChange,
                                    }: PaginationProps) {
     const isRTL = useIsRTL()
+    const { locale } = useI18n()
+    const d = React.useCallback((v: number | string) => convertDigitsByLocale(v, locale), [locale])
 
     const totalPages = Math.max(0, pages)
     const currentPage = totalPages === 0 ? 0 : Math.min(page + 1, totalPages)
@@ -73,16 +77,16 @@ export default function Pagination({
                         </Label>
                         <Select
                             value={`${pageSize}`}
-                            onValueChange={(v) => onPageSizeChange?.(Number(v))}
+                            onValueChange={(v: string) => onPageSizeChange?.(Number(v))}
                             disabled={allDisabled}
                         >
                             <SelectTrigger id="rows-per-page" size="sm" className="w-20">
-                                <SelectValue placeholder={pageSize} />
+                                <SelectValue placeholder={d(pageSize ?? "")} />
                             </SelectTrigger>
                             <SelectContent side="top">
                                 {pageSizeOptions.map((ps) => (
                                     <SelectItem key={ps} value={`${ps}`}>
-                                        {ps}
+                                        {d(ps)}
                                     </SelectItem>
                                 ))}
                             </SelectContent>
@@ -93,7 +97,7 @@ export default function Pagination({
 
             <div className="flex items-center gap-6">
                 <div className="text-sm font-medium" aria-live="polite">
-                    {labels.page} {currentPage} {labels.of} {totalPages}
+                    {labels.page} {d(currentPage)} {labels.of} {d(totalPages)}
                 </div>
 
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
Localize pagination numbers in the brand list to consistently display Persian digits for the `fa` locale.

---
<a href="https://cursor.com/background-agent?bcId=bc-94382009-101a-4386-a2e1-ea58e2a9f489">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94382009-101a-4386-a2e1-ea58e2a9f489">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

