### PR TITLE
refactor: extract dashboard layout

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { SiteHeader } from "@/components/layout/site-header"
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/features/sidebar/app-sidebar"
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <SidebarProvider
+            style={
+                {
+                    "--sidebar-width": "calc(var(--spacing)*72)",
+                    "--header-height": "calc(var(--spacing)*12)",
+                } as React.CSSProperties
+            }
+        >
+            <AppSidebar variant="inset" />
+            <SidebarInset>
+                <SiteHeader />
+                {children}
+            </SidebarInset>
+        </SidebarProvider>
+    )
+}

--- a/src/features/brands/pages/AddBrand/AddBrandPage.tsx
+++ b/src/features/brands/pages/AddBrand/AddBrandPage.tsx
@@ -5,12 +5,10 @@ import { JSX } from "react"
 import { useNavigate } from "react-router-dom"
 
 import { ROUTES } from "@/app/routes/routes"
-import { SiteHeader } from "@/components/layout/site-header"
 import { Button } from "@/components/ui/button"
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import DashboardLayout from "@/components/layout/DashboardLayout"
 import BrandForm from "@/features/brands/components/layout/Form/BrandForm"
 import type { CreateBrandRequest } from "@/features/brands/model/types"
-import { AppSidebar } from "@/features/sidebar/app-sidebar"
 import { useI18n } from "@/shared/hooks/useI18n"
 import { isRTLLocale } from "@/shared/i18n/utils"
 import { brandsQueries } from "@/features/brands"
@@ -50,54 +48,43 @@ export default function AddBrandPage(): JSX.Element {
     }
 
     return (
-        <SidebarProvider
-            style={
-                {
-                    "--sidebar-width": "calc(var(--spacing)*72)",
-                    "--header-height": "calc(var(--spacing)*12)",
-                } as React.CSSProperties
-            }
-        >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-                <SiteHeader />
-                <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                className="shadow-none"
-                                onClick={() => navigate(-1)}
-                                aria-label={t("common.back")}
-                                title={t("common.back")}
-                            >
-                                {rtl ? (
-                                    <ArrowRight className="h-4 w-4" />
-                                ) : (
-                                    <ArrowLeft className="h-4 w-4" />
-                                )}
-                            </Button>
-                            <h1 className="text-2xl font-bold tracking-tight">
-                                {t("brands.add")}
-                            </h1>
-                        </div>
-
-                        <div className="flex items-center gap-2">
-                            <Button type="submit" form={FORM_ID} disabled={createMutation.isPending}>
-                                {createMutation.isPending ? t("common.saving") : t("common.save")}
-                            </Button>
-                        </div>
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={() => navigate(-1)}
+                            aria-label={t("common.back")}
+                            title={t("common.back")}
+                        >
+                            {rtl ? (
+                                <ArrowRight className="h-4 w-4" />
+                            ) : (
+                                <ArrowLeft className="h-4 w-4" />
+                            )}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">
+                            {t("brands.add")}
+                        </h1>
                     </div>
 
-                    <BrandForm
-                        formId={FORM_ID}
-                        onSubmit={handleSubmit}
-                        submitting={createMutation.isPending}
-                        apiErrors={apiErrors}
-                    />
+                    <div className="flex items-center gap-2">
+                        <Button type="submit" form={FORM_ID} disabled={createMutation.isPending}>
+                            {createMutation.isPending ? t("common.saving") : t("common.save")}
+                        </Button>
+                    </div>
                 </div>
-            </SidebarInset>
-        </SidebarProvider>
+
+                <BrandForm
+                    formId={FORM_ID}
+                    onSubmit={handleSubmit}
+                    submitting={createMutation.isPending}
+                    apiErrors={apiErrors}
+                />
+            </div>
+        </DashboardLayout>
     )
 }

--- a/src/features/brands/pages/DetailBrand/DetailBrandPage.tsx
+++ b/src/features/brands/pages/DetailBrand/DetailBrandPage.tsx
@@ -1,8 +1,6 @@
 import * as React from "react"
 import { useParams, useNavigate } from "react-router-dom"
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { AppSidebar } from "@/features/sidebar/app-sidebar"
-import { SiteHeader } from "@/components/layout/site-header"
+import DashboardLayout from "@/components/layout/DashboardLayout"
 import { Card, CardContent } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { Button } from "@/components/ui/button"
@@ -34,27 +32,21 @@ export default function DetailBrandPage() {
 
     if (isLoading) {
         return (
-            <SidebarProvider
-                style={{ "--sidebar-width": "calc(var(--spacing)*72)", "--header-height": "calc(var(--spacing)*12)" } as React.CSSProperties}
-            >
-                <AppSidebar variant="inset" />
-                <SidebarInset>
-                    <SiteHeader />
-                    <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                                <div className="h-9 w-9 rounded bg-muted/30" />
-                                <div className="h-6 w-48 rounded bg-muted/30" />
-                            </div>
-                            <div className="h-9 w-24 rounded bg-muted/30" />
+            <DashboardLayout>
+                <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <div className="h-9 w-9 rounded bg-muted/30" />
+                            <div className="h-6 w-48 rounded bg-muted/30" />
                         </div>
-                        <div className="grid gap-6 md:grid-cols-2">
-                            <div className="h-80 rounded-lg border bg-muted/30" />
-                            <div className="h-80 rounded-lg border bg-muted/30" />
-                        </div>
+                        <div className="h-9 w-24 rounded bg-muted/30" />
                     </div>
-                </SidebarInset>
-            </SidebarProvider>
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="h-80 rounded-lg border bg-muted/30" />
+                        <div className="h-80 rounded-lg border bg-muted/30" />
+                    </div>
+                </div>
+            </DashboardLayout>
         )
     }
 
@@ -64,100 +56,89 @@ export default function DetailBrandPage() {
 
     if (!brand) {
         return (
-            <SidebarProvider
-                style={{ "--sidebar-width": "calc(var(--spacing)*72)", "--header-height": "calc(var(--spacing)*12)" } as React.CSSProperties}
-            >
-                <AppSidebar variant="inset" />
-                <SidebarInset>
-                    <SiteHeader />
-                    <div className="px-4 lg:px-6 py-10 text-sm text-muted-foreground">{t("common.no_results")}</div>
-                </SidebarInset>
-            </SidebarProvider>
+            <DashboardLayout>
+                <div className="px-4 lg:px-6 py-10 text-sm text-muted-foreground">
+                    {t("common.no_results")}
+                </div>
+            </DashboardLayout>
         )
     }
 
     return (
-        <SidebarProvider
-            style={{ "--sidebar-width": "calc(var(--spacing)*72)", "--header-height": "calc(var(--spacing)*12)" } as React.CSSProperties}
-        >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-                <SiteHeader />
-
-                <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                className="shadow-none"
-                                onClick={goBack}
-                                aria-label={t("common.back")}
-                                title={t("common.back")}
-                            >
-                                {rtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
-                            </Button>
-                            <h1 className="text-2xl font-bold tracking-tight">{t("brands.details.title")}</h1>
-                        </div>
-
-                        <div className="flex items-center gap-2">
-                            <Button onClick={goEdit}>{t("brands.actions.edit")}</Button>
-                        </div>
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={goBack}
+                            aria-label={t("common.back")}
+                            title={t("common.back")}
+                        >
+                            {rtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">{t("brands.details.title")}</h1>
                     </div>
 
-                    <Card className="overflow-hidden">
-                        <CardContent className="p-6">
-                            <div className="grid gap-8 md:grid-cols-2">
-                                {/* Left: info fields */}
-                                <div className="grid gap-5">
-                                    <Field label={t("brands.table.name")} value={brand.name || "-"} />
-                                    <Separator />
-                                    <Field label={t("brands.table.country")} value={brand.country || "-"} />
-                                    <Separator />
-                                    <div className="grid gap-2">
-                                        <span className="text-xs text-muted-foreground">{t("brands.table.website")}</span>
-                                        {brand.website ? (
-                                            <a
-                                                href={brand.website}
-                                                target="_blank"
-                                                rel="noopener noreferrer external"
-                                                className="inline-flex max-w-[48ch] items-center gap-1 truncate underline-offset-4 hover:underline"
-                                                title={brand.website}
-                                            >
-                                                <span className="truncate">{brand.website}</span>
-                                                <ExternalLink className="h-3.5 w-3.5 shrink-0" />
-                                            </a>
-                                        ) : (
-                                            <span>-</span>
-                                        )}
-                                    </div>
-                                    <Separator />
-                                    <div className="grid gap-2">
-                                        <span className="text-xs text-muted-foreground">{t("brands.form.description")}</span>
-                                        <p className="whitespace-pre-wrap text-sm leading-6">{brand.description || "—"}</p>
-                                    </div>
-                                </div>
+                    <div className="flex items-center gap-2">
+                        <Button onClick={goEdit}>{t("brands.actions.edit")}</Button>
+                    </div>
+                </div>
 
-                                {/* Right: logo/image */}
-                                <div className="flex items-start justify-center">
-                                    {brand.logo_url ? (
-                                        <img
-                                            src={toAbsoluteUrl(brand.logo_url)}
-                                            alt={t("brands.logo_alt") as string}
-                                            className="h-72 w-full max-w-[360px] rounded-lg object-contain border bg-background"
-                                            loading="lazy"
-                                            decoding="async"
-                                        />
+                <Card className="overflow-hidden">
+                    <CardContent className="p-6">
+                        <div className="grid gap-8 md:grid-cols-2">
+                            {/* Left: info fields */}
+                            <div className="grid gap-5">
+                                <Field label={t("brands.table.name")} value={brand.name || "-"} />
+                                <Separator />
+                                <Field label={t("brands.table.country")} value={brand.country || "-"} />
+                                <Separator />
+                                <div className="grid gap-2">
+                                    <span className="text-xs text-muted-foreground">{t("brands.table.website")}</span>
+                                    {brand.website ? (
+                                        <a
+                                            href={brand.website}
+                                            target="_blank"
+                                            rel="noopener noreferrer external"
+                                            className="inline-flex max-w-[48ch] items-center gap-1 truncate underline-offset-4 hover:underline"
+                                            title={brand.website}
+                                        >
+                                            <span className="truncate">{brand.website}</span>
+                                            <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+                                        </a>
                                     ) : (
-                                        <div className="h-72 w-full max-w-[360px] rounded-lg border bg-muted/30" />
+                                        <span>-</span>
                                     )}
                                 </div>
+                                <Separator />
+                                <div className="grid gap-2">
+                                    <span className="text-xs text-muted-foreground">{t("brands.form.description")}</span>
+                                    <p className="whitespace-pre-wrap text-sm leading-6">{brand.description || "—"}</p>
+                                </div>
                             </div>
-                        </CardContent>
-                    </Card>
-                </div>
-            </SidebarInset>
-        </SidebarProvider>
+
+                            {/* Right: logo/image */}
+                            <div className="flex items-start justify-center">
+                                {brand.logo_url ? (
+                                    <img
+                                        src={toAbsoluteUrl(brand.logo_url)}
+                                        alt={t("brands.logo_alt") as string}
+                                        className="h-72 w-full max-w-[360px] rounded-lg object-contain border bg-background"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                ) : (
+                                    <div className="h-72 w-full max-w-[360px] rounded-lg border bg-muted/30" />
+                                )}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </DashboardLayout>
     )
 }
 

--- a/src/features/brands/pages/EditBrand/index.tsx
+++ b/src/features/brands/pages/EditBrand/index.tsx
@@ -1,7 +1,5 @@
 import * as React from "react"
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { AppSidebar } from "@/features/sidebar/app-sidebar"
-import { SiteHeader } from "@/components/layout/site-header"
+import DashboardLayout from "@/components/layout/DashboardLayout"
 import { BrandsEditBodySkeleton } from "./Skeletons"
 import ErrorFallback from "@/components/layout/ErrorFallback"
 import EditBrandUI from "./Ui"
@@ -36,20 +34,5 @@ export default function EditBrandPage() {
         )
     }
 
-    return (
-        <SidebarProvider
-            style={
-                {
-                    "--sidebar-width": "calc(var(--spacing)*72)",
-                    "--header-height": "calc(var(--spacing)*12)",
-                } as React.CSSProperties
-            }
-        >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-                <SiteHeader />
-                {renderContent()}
-            </SidebarInset>
-        </SidebarProvider>
-    )
+    return <DashboardLayout>{renderContent()}</DashboardLayout>
 }

--- a/src/features/brands/pages/ListBrands/index.tsx
+++ b/src/features/brands/pages/ListBrands/index.tsx
@@ -1,7 +1,5 @@
 import * as React from "react"
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
-import { AppSidebar } from "@/features/sidebar/app-sidebar"
-import { SiteHeader } from "@/components/layout/site-header"
+import DashboardLayout from "@/components/layout/DashboardLayout"
 import { useBrandsPageContainer } from "./Container"
 import BrandsPageUI from "./Ui"
 import { BrandsBodySkeleton } from "./Skeletons"
@@ -76,20 +74,5 @@ export default function BrandsPage() {
         )
     }
 
-    return (
-        <SidebarProvider
-            style={
-                {
-                    "--sidebar-width": "calc(var(--spacing)*72)",
-                    "--header-height": "calc(var(--spacing)*12)",
-                } as React.CSSProperties
-            }
-        >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-                <SiteHeader />
-                {renderContent()}
-            </SidebarInset>
-        </SidebarProvider>
-    )
+    return <DashboardLayout>{renderContent()}</DashboardLayout>
 }

--- a/src/features/dashboard/pages/DashboardPage.tsx
+++ b/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,24 +1,11 @@
 import React from 'react'
 
-import { SiteHeader } from '@/components/layout/site-header.tsx'
-import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
-import { AppSidebar } from '@/features/sidebar/app-sidebar.tsx'
+import DashboardLayout from '@/components/layout/DashboardLayout'
 
 export default function Page() {
     return (
-        <SidebarProvider
-            style={
-                {
-                    '--sidebar-width': 'calc(var(--spacing) * 72)',
-                    '--header-height': 'calc(var(--spacing) * 12)',
-                } as React.CSSProperties
-            }
-        >
-            <AppSidebar variant="inset" />
-            <SidebarInset>
-                <SiteHeader />
-                <div className="flex flex-1 flex-col"></div>
-            </SidebarInset>
-        </SidebarProvider>
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col"></div>
+        </DashboardLayout>
     )
 }


### PR DESCRIPTION
## Summary
- add reusable DashboardLayout wrapping sidebar and header
- use DashboardLayout in dashboard and brand pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc518407708323bd17524599ec2b59