### PR TITLE
Refactor brands list layout with modular states

### DIFF
--- a/src/features/brands/components/layout/Table/BrandsTable.tsx
+++ b/src/features/brands/components/layout/Table/BrandsTable.tsx
@@ -66,19 +66,12 @@ export default function BrandsTable({
                 </TableHeader>
 
                 <TableBody>
-                    {items.length === 0 ? (
-                        <TableRow>
-                            <TableCell colSpan={5} className="h-24 px-3 text-center text-sm text-muted-foreground">
-                                {t("common.no_results")}
-                            </TableCell>
-                        </TableRow>
-                    ) : (
-                        items.map((b) => (
-                            <TableRow
-                                key={b.id}
-                                className="h-12 cursor-pointer hover:bg-muted/40 focus-visible:bg-muted/40"
-                                onClick={() => goDetail(b.id)}
-                                tabIndex={0}
+                    {items.map((b) => (
+                        <TableRow
+                            key={b.id}
+                            className="h-12 cursor-pointer hover:bg-muted/40 focus-visible:bg-muted/40"
+                            onClick={() => goDetail(b.id)}
+                            tabIndex={0}
                                 onKeyDown={(e) => {
                                     if (e.key === "Enter" || e.key === " ") {
                                         e.preventDefault();
@@ -158,8 +151,7 @@ export default function BrandsTable({
                                     </DropdownMenu>
                                 </TableCell>
                             </TableRow>
-                        ))
-                    )}
+                        ))}
                 </TableBody>
             </Table>
         </div>

--- a/src/features/brands/pages/ListBrands/Empty.tsx
+++ b/src/features/brands/pages/ListBrands/Empty.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { useI18n } from "@/shared/hooks/useI18n";
+
+export function BrandsEmpty() {
+    const { t } = useI18n();
+    return (
+        <div className="flex h-40 items-center justify-center rounded-lg border text-sm text-muted-foreground">
+            {t("common.no_results")}
+        </div>
+    );
+}

--- a/src/features/brands/pages/ListBrands/Skeletons.tsx
+++ b/src/features/brands/pages/ListBrands/Skeletons.tsx
@@ -1,60 +1,44 @@
 // features/brands/pages/ListBrands/Skeletons.tsx
 import * as React from "react";
-import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 
-export function BrandsBodySkeleton() {
+export function BrandsTableSkeleton() {
     return (
-        <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
-            <div className="flex items-center justify-between px-4 lg:px-6">
-                <div className="flex flex-col gap-2">
-                    <Skeleton className="h-7 w-44" />
-                    <Skeleton className="h-4 w-72" />
-                </div>
-                <div className="flex items-center gap-3">
-                    <Skeleton className="h-9 w-72" />
-                    <Skeleton className="h-9 w-28" />
-                </div>
-            </div>
+        <div className="rounded-xl border p-3">
+            <table className="w-full">
+                <thead>
+                <tr>
+                    {["1", "2", "3", "4"].map((k) => (
+                        <th key={k} className="p-3 text-left">
+                            <Skeleton className="h-4 w-16" />
+                        </th>
+                    ))}
+                </tr>
+                </thead>
+                <tbody>
+                {[...Array(8)].map((_, i) => (
+                    <tr key={i} className="border-t">
+                        <td className="p-3"><Skeleton className="h-4 w-40" /></td>
+                        <td className="p-3"><Skeleton className="h-4 w-28" /></td>
+                        <td className="p-3"><Skeleton className="h-10 w-10 rounded-md" /></td>
+                        <td className="p-3"><Skeleton className="h-8 w-24" /></td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
 
-            <Separator className="mx-4 lg:mx-6" />
-
-            <div className="px-4 lg:px-6">
-                <div className="rounded-xl border p-3">
-                    <table className="w-full">
-                        <thead>
-                        <tr>
-                            {["1", "2", "3", "4"].map((k) => (
-                                <th key={k} className="p-3 text-left">
-                                    <Skeleton className="h-4 w-16" />
-                                </th>
-                            ))}
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {[...Array(8)].map((_, i) => (
-                            <tr key={i} className="border-t">
-                                <td className="p-3"><Skeleton className="h-4 w-40" /></td>
-                                <td className="p-3"><Skeleton className="h-4 w-28" /></td>
-                                <td className="p-3"><Skeleton className="h-10 w-10 rounded-md" /></td>
-                                <td className="p-3"><Skeleton className="h-8 w-24" /></td>
-                            </tr>
-                        ))}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-
-            <div className="px-4 lg:px-6">
-                <div className="flex flex-col items-center gap-3 p-3 sm:flex-row sm:justify-between">
-                    <Skeleton className="h-4 w-40" />
-                    <div className="flex items-center gap-2">
-                        <Skeleton className="h-8 w-20" />
-                        <Skeleton className="h-8 w-20" />
-                        <Skeleton className="h-8 w-20" />
-                        <Skeleton className="h-8 w-20" />
-                    </div>
-                </div>
+export function BrandsPaginationSkeleton() {
+    return (
+        <div className="flex flex-col items-center gap-3 p-3 sm:flex-row sm:justify-between">
+            <Skeleton className="h-4 w-40" />
+            <div className="flex items-center gap-2">
+                <Skeleton className="h-8 w-20" />
+                <Skeleton className="h-8 w-20" />
+                <Skeleton className="h-8 w-20" />
+                <Skeleton className="h-8 w-20" />
             </div>
         </div>
     );

--- a/src/features/brands/pages/ListBrands/Ui.tsx
+++ b/src/features/brands/pages/ListBrands/Ui.tsx
@@ -2,9 +2,6 @@ import * as React from "react"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import Pagination, { PaginationProps } from "@/features/brands/components/ui/Pagination"
-import type { BrandData } from "@/features/brands/model/types"
-import BrandsTable from "@/features/brands/components/layout/Table/BrandsTable"
 import { Search } from "lucide-react"
 
 type Props = {
@@ -15,11 +12,9 @@ type Props = {
     query: string
     onQueryChange: (v: string) => void
     onAdd: () => void
-    items: BrandData[]
-    onDelete: (id: string) => void
-    pagination: Omit<PaginationProps, "labels">
     isFetching?: boolean
-    labels: PaginationProps["labels"]
+    children: React.ReactNode
+    pagination?: React.ReactNode
 }
 
 export default function BrandsPageUI({
@@ -30,11 +25,9 @@ export default function BrandsPageUI({
                                          query,
                                          onQueryChange,
                                          onAdd,
-                                         items,
-                                         onDelete,
-                                         pagination,
                                          isFetching = false,
-                                         labels,
+                                         children,
+                                         pagination,
                                      }: Props) {
     return (
         <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
@@ -71,13 +64,11 @@ export default function BrandsPageUI({
             <div className="px-4 lg:px-6">
                 <div className={isFetching ? "relative" : ""}>
                     {isFetching && <div className="absolute inset-0 rounded-lg bg-background/40" />}
-                    <BrandsTable items={items} onDelete={onDelete} />
+                    {children}
                 </div>
             </div>
 
-            <div className="px-4 lg:px-6">
-                <Pagination {...pagination} disabled={isFetching} labels={labels} />
-            </div>
+            {pagination && <div className="px-4 lg:px-6">{pagination}</div>}
         </div>
     )
 }

--- a/src/features/brands/pages/ListBrands/index.tsx
+++ b/src/features/brands/pages/ListBrands/index.tsx
@@ -2,7 +2,10 @@ import * as React from "react"
 import DashboardLayout from "@/components/layout/DashboardLayout"
 import { useBrandsPageContainer } from "./Container"
 import BrandsPageUI from "./Ui"
-import { BrandsBodySkeleton } from "./Skeletons"
+import { BrandsTableSkeleton, BrandsPaginationSkeleton } from "./Skeletons"
+import { BrandsEmpty } from "./Empty"
+import BrandsTable from "@/features/brands/components/layout/Table/BrandsTable"
+import Pagination from "@/features/brands/components/ui/Pagination"
 import ErrorFallback from "@/components/layout/ErrorFallback"
 
 export default function BrandsPage() {
@@ -20,9 +23,7 @@ export default function BrandsPage() {
             ? (t("common.showing_count", { count: list.total }) as string)
             : (t("common.search_hint") as string)
 
-    const renderContent = () => {
-        if (status.isLoading) return <BrandsBodySkeleton />
-
+    const content = () => {
         if (status.isError) {
             return (
                 <ErrorFallback
@@ -32,7 +33,42 @@ export default function BrandsPage() {
             )
         }
 
-        return (
+        if (status.isLoading) return <BrandsTableSkeleton />
+        if (list.items.length === 0) return <BrandsEmpty />
+
+        return <BrandsTable items={list.items} onDelete={actions.handleDelete} />
+    }
+
+    const paginationNode = status.isLoading ? (
+        <BrandsPaginationSkeleton />
+    ) : list.items.length > 0 ? (
+        <Pagination
+            page={queryState.page}
+            pages={list.totalPages}
+            hasPrev={list.hasPrev}
+            hasNext={list.hasNext}
+            disabled={status.isLoading}
+            onFirst={actions.goFirst}
+            onPrev={actions.goPrev}
+            onNext={actions.goNext}
+            onLast={actions.goLast}
+            pageSize={queryState.pageSize}
+            pageSizeOptions={[5, 10, 20, 30, 50]}
+            onPageSizeChange={queryState.setPageSize}
+            labels={{
+                first: t("pagination.first") as string,
+                prev: t("pagination.prev") as string,
+                next: t("pagination.next") as string,
+                last: t("pagination.last") as string,
+                rowsPerPage: t("pagination.rowsPerPage") as string,
+                page: t("pagination.page") as string,
+                of: t("pagination.of") as string,
+            }}
+        />
+    ) : null
+
+    return (
+        <DashboardLayout>
             <BrandsPageUI
                 title={t("brands.title") as string}
                 subtitle={subtitle}
@@ -44,35 +80,11 @@ export default function BrandsPage() {
                     queryState.setPage(0)
                 }}
                 onAdd={() => nav.navigate(nav.ROUTES.BRAND.NEW)}
-                items={list.items}
-                onDelete={actions.handleDelete}
-                pagination={{
-                    page: queryState.page,
-                    pages: list.totalPages,
-                    hasPrev: list.hasPrev,
-                    hasNext: list.hasNext,
-                    disabled: status.isLoading,
-                    onFirst: actions.goFirst,
-                    onPrev: actions.goPrev,
-                    onNext: actions.goNext,
-                    onLast: actions.goLast,
-                    pageSize: queryState.pageSize,
-                    pageSizeOptions: [5, 10, 20, 30, 50],
-                    onPageSizeChange: queryState.setPageSize,
-                }}
                 isFetching={status.isFetching}
-                labels={{
-                    first: t("pagination.first") as string,
-                    prev: t("pagination.prev") as string,
-                    next: t("pagination.next") as string,
-                    last: t("pagination.last") as string,
-                    rowsPerPage: t("pagination.rowsPerPage") as string,
-                    page: t("pagination.page") as string,
-                    of: t("pagination.of") as string,
-                }}
-            />
-        )
-    }
-
-    return <DashboardLayout>{renderContent()}</DashboardLayout>
+                pagination={paginationNode}
+            >
+                {content()}
+            </BrandsPageUI>
+        </DashboardLayout>
+    )
 }


### PR DESCRIPTION
## Summary
- Extract BrandsEmpty component for "no results" messaging
- Split table and pagination skeletons and simplify BrandsPage layout
- Move state handling to page and keep layout constant

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: plugins must be defined as objects in flat config)


------
https://chatgpt.com/codex/tasks/task_e_68bc56a1cf38832381abb174e46a59df