### PR TITLE
Refactor brand form into modular input sections

### DIFF
--- a/src/features/brands/components/layout/Form/BrandCountryWebsiteFields.tsx
+++ b/src/features/brands/components/layout/Form/BrandCountryWebsiteFields.tsx
@@ -1,0 +1,50 @@
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { useI18n } from '@/shared/hooks/useI18n.ts'
+import { useFormContext } from 'react-hook-form'
+import { CreateBrandRequest } from '@/features/brands/model/types.ts'
+
+export default function BrandCountryWebsiteFields() {
+    const { t } = useI18n()
+    const {
+        register,
+        formState: { errors },
+    } = useFormContext<CreateBrandRequest>()
+
+    return (
+        <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+                <Label htmlFor="brand-country">{t('brands.form.country')}</Label>
+                <Input
+                    id="brand-country"
+                    placeholder={t('brands.form.country_ph')}
+                    autoComplete="country-name"
+                    aria-invalid={Boolean(errors.country)}
+                    {...register('country')}
+                />
+                {errors.country && (
+                    <p className="mt-1 text-xs text-destructive">
+                        {errors.country.message}
+                    </p>
+                )}
+            </div>
+
+            <div>
+                <Label htmlFor="brand-website">{t('brands.form.website')}</Label>
+                <Input
+                    id="brand-website"
+                    placeholder={t('brands.form.website_ph')}
+                    inputMode="url"
+                    autoComplete="url"
+                    aria-invalid={Boolean(errors.website)}
+                    {...register('website')}
+                />
+                {errors.website && (
+                    <p className="mt-1 text-xs text-destructive">
+                        {errors.website.message}
+                    </p>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/features/brands/components/layout/Form/BrandForm.tsx
+++ b/src/features/brands/components/layout/Form/BrandForm.tsx
@@ -5,14 +5,14 @@ import { z } from 'zod'
 import * as React from 'react'
 import { JSX } from 'react'
 
-import { useForm } from 'react-hook-form'
+import { FormProvider, useForm } from 'react-hook-form'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.tsx'
-import { Input } from '@/components/ui/input.tsx'
-import { Label } from '@/components/ui/label.tsx'
 import { useI18n } from '@/shared/hooks/useI18n.ts'
-import {CreateBrandRequest} from "@/features/brands/model/types.ts";
-import BrandLogoUploader from '@/features/brands/components/layout/Uploader/BrandLogoUploader.tsx'
+import { CreateBrandRequest } from '@/features/brands/model/types.ts'
+import BrandGeneralFields from './BrandGeneralFields.tsx'
+import BrandCountryWebsiteFields from './BrandCountryWebsiteFields.tsx'
+import BrandLogoField from './BrandLogoField.tsx'
 
 function normalizeUrl(value: string): string {
     const trimmed = value.trim()
@@ -89,15 +89,7 @@ export default function BrandForm({
         [t],
     )
 
-    const {
-        register,
-        handleSubmit,
-        setValue,
-        watch,
-        formState: { errors },
-        setError,
-        reset,
-    } = useForm<CreateBrandRequest>({
+    const form = useForm<CreateBrandRequest>({
         resolver: zodResolver(schema),
         defaultValues: {
             name: '',
@@ -110,6 +102,8 @@ export default function BrandForm({
         mode: 'onBlur',
     })
 
+    const { handleSubmit, reset, setError } = form
+
     React.useEffect(() => {
         if (defaultValues) {
             reset({
@@ -121,8 +115,6 @@ export default function BrandForm({
             })
         }
     }, [defaultValues, reset])
-
-    const [logoPreviewUrl, setLogoPreviewUrl] = React.useState<string>(initialLogoUrl || '')
 
     React.useEffect(() => {
         if (!apiErrors || apiErrors.length === 0) return
@@ -141,119 +133,38 @@ export default function BrandForm({
     }, [apiErrors, setError])
 
     return (
-        <form
-            id={formId}
-            noValidate
-            className="grid gap-6"
-            onSubmit={handleSubmit((values) => {
-                const cleaned: CreateBrandRequest = {
-                    name: values.name.trim(),
-                    description: values.description?.trim() || '',
-                    country: values.country?.trim() || '',
-                    website: values.website ? normalizeUrl(values.website) : '',
-                    logo_id: values.logo_id?.trim() || '',
-                }
-                onSubmit(cleaned)
-            })}
-        >
-            <Card className="overflow-hidden shadow-sm">
-                <CardHeader className="bg-muted/50">
-                    <CardTitle className="text-lg font-semibold">
-                        {t('brands.form.title')}
-                    </CardTitle>
-                </CardHeader>
+        <FormProvider {...form}>
+            <form
+                id={formId}
+                noValidate
+                className="grid gap-6"
+                onSubmit={handleSubmit((values) => {
+                    const cleaned: CreateBrandRequest = {
+                        name: values.name.trim(),
+                        description: values.description?.trim() || '',
+                        country: values.country?.trim() || '',
+                        website: values.website ? normalizeUrl(values.website) : '',
+                        logo_id: values.logo_id?.trim() || '',
+                    }
+                    onSubmit(cleaned)
+                })}
+            >
+                <Card className="overflow-hidden shadow-sm">
+                    <CardHeader className="bg-muted/50">
+                        <CardTitle className="text-lg font-semibold">
+                            {t('brands.form.title')}
+                        </CardTitle>
+                    </CardHeader>
 
-                <CardContent className="grid gap-6 p-6 md:grid-cols-2">
-                    <div className="flex flex-col gap-4">
-                        <div>
-                            <Label htmlFor="brand-name">{t('brands.form.name')}*</Label>
-                            <Input
-                                id="brand-name"
-                                placeholder={t('brands.form.name_ph')}
-                                autoComplete="organization"
-                                aria-invalid={Boolean(errors.name)}
-                                {...register('name')}
-                            />
-                            {errors.name && (
-                                <p className="mt-1 text-xs text-destructive">
-                                    {errors.name.message}
-                                </p>
-                            )}
+                    <CardContent className="grid gap-6 p-6 md:grid-cols-2">
+                        <div className="flex flex-col gap-4">
+                            <BrandGeneralFields />
+                            <BrandCountryWebsiteFields />
                         </div>
-
-                        <div className="grid gap-4 sm:grid-cols-2">
-                            <div>
-                                <Label htmlFor="brand-country">{t('brands.form.country')}</Label>
-                                <Input
-                                    id="brand-country"
-                                    placeholder={t('brands.form.country_ph')}
-                                    autoComplete="country-name"
-                                    aria-invalid={Boolean(errors.country)}
-                                    {...register('country')}
-                                />
-                                {errors.country && (
-                                    <p className="mt-1 text-xs text-destructive">
-                                        {errors.country.message}
-                                    </p>
-                                )}
-                            </div>
-
-                            <div>
-                                <Label htmlFor="brand-website">{t('brands.form.website')}</Label>
-                                <Input
-                                    id="brand-website"
-                                    placeholder={t('brands.form.website_ph')}
-                                    inputMode="url"
-                                    autoComplete="url"
-                                    aria-invalid={Boolean(errors.website)}
-                                    {...register('website')}
-                                />
-                                {errors.website && (
-                                    <p className="mt-1 text-xs text-destructive">
-                                        {errors.website.message}
-                                    </p>
-                                )}
-                            </div>
-                        </div>
-
-                        <div>
-                            <Label htmlFor="brand-description">
-                                {t('brands.form.description')}
-                            </Label>
-                            <textarea
-                                id="brand-description"
-                                placeholder={t('brands.form.description_ph')}
-                                className="min-h-24 w-full resize-vertical rounded-md border bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50"
-                                aria-invalid={Boolean(errors.description)}
-                                {...register('description')}
-                            />
-                            {errors.description && (
-                                <p className="mt-1 text-xs text-destructive">
-                                    {errors.description.message}
-                                </p>
-                            )}
-                        </div>
-                    </div>
-
-                    <div className="flex flex-col">
-                        <BrandLogoUploader
-                            value={logoPreviewUrl || ''}
-                            onChange={(file) => {
-                                const id = file?.id || ''
-                                const url = file?.url || ''
-                                setLogoPreviewUrl(url)
-                                setValue('logo_id', id, { shouldDirty: true })
-                            }}
-                            label={t('brands.form.logo')}
-                            aspect="square"
-                            className="h-56 w-full self-start"
-                        />
-                        <p className="mt-2 text-xs text-muted-foreground">
-                            {t('brands.form.logo_help')}
-                        </p>
-                    </div>
-                </CardContent>
-            </Card>
-        </form>
+                        <BrandLogoField initialLogoUrl={initialLogoUrl} />
+                    </CardContent>
+                </Card>
+            </form>
+        </FormProvider>
     )
 }

--- a/src/features/brands/components/layout/Form/BrandGeneralFields.tsx
+++ b/src/features/brands/components/layout/Form/BrandGeneralFields.tsx
@@ -1,0 +1,51 @@
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { useI18n } from '@/shared/hooks/useI18n.ts'
+import { useFormContext } from 'react-hook-form'
+import { CreateBrandRequest } from '@/features/brands/model/types.ts'
+
+export default function BrandGeneralFields() {
+    const { t } = useI18n()
+    const {
+        register,
+        formState: { errors },
+    } = useFormContext<CreateBrandRequest>()
+
+    return (
+        <>
+            <div>
+                <Label htmlFor="brand-name">{t('brands.form.name')}*</Label>
+                <Input
+                    id="brand-name"
+                    placeholder={t('brands.form.name_ph')}
+                    autoComplete="organization"
+                    aria-invalid={Boolean(errors.name)}
+                    {...register('name')}
+                />
+                {errors.name && (
+                    <p className="mt-1 text-xs text-destructive">
+                        {errors.name.message}
+                    </p>
+                )}
+            </div>
+
+            <div>
+                <Label htmlFor="brand-description">
+                    {t('brands.form.description')}
+                </Label>
+                <textarea
+                    id="brand-description"
+                    placeholder={t('brands.form.description_ph')}
+                    className="min-h-24 w-full resize-vertical rounded-md border bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-invalid={Boolean(errors.description)}
+                    {...register('description')}
+                />
+                {errors.description && (
+                    <p className="mt-1 text-xs text-destructive">
+                        {errors.description.message}
+                    </p>
+                )}
+            </div>
+        </>
+    )
+}

--- a/src/features/brands/components/layout/Form/BrandLogoField.tsx
+++ b/src/features/brands/components/layout/Form/BrandLogoField.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { useFormContext } from 'react-hook-form'
+import BrandLogoUploader from '@/features/brands/components/layout/Uploader/BrandLogoUploader.tsx'
+import { useI18n } from '@/shared/hooks/useI18n.ts'
+import { CreateBrandRequest } from '@/features/brands/model/types.ts'
+
+type Props = Readonly<{
+    initialLogoUrl?: string | null
+}>
+
+export default function BrandLogoField({ initialLogoUrl }: Props) {
+    const { t } = useI18n()
+    const { setValue } = useFormContext<CreateBrandRequest>()
+    const [logoPreviewUrl, setLogoPreviewUrl] = React.useState(initialLogoUrl || '')
+
+    React.useEffect(() => {
+        setLogoPreviewUrl(initialLogoUrl || '')
+    }, [initialLogoUrl])
+
+    return (
+        <div className="flex flex-col">
+            <BrandLogoUploader
+                value={logoPreviewUrl || ''}
+                onChange={(file) => {
+                    const id = file?.id || ''
+                    const url = file?.url || ''
+                    setLogoPreviewUrl(url)
+                    setValue('logo_id', id, { shouldDirty: true })
+                }}
+                label={t('brands.form.logo')}
+                aspect="square"
+                className="h-56 w-full self-start"
+            />
+            <p className="mt-2 text-xs text-muted-foreground">
+                {t('brands.form.logo_help')}
+            </p>
+        </div>
+    )
+}


### PR DESCRIPTION
## Summary
- extract general information inputs into `BrandGeneralFields`
- move country and website inputs into `BrandCountryWebsiteFields`
- encapsulate logo upload logic in `BrandLogoField` and simplify `BrandForm` composition

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Flat config requires "plugins" to be an object)*

------
https://chatgpt.com/codex/tasks/task_e_68bc582d192c8323a5b091a2ec6cd47e