### PR TITLE
feat: add categories CRUD feature

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -12,6 +12,10 @@ import AddBrandPage from '@/features/brands/pages/AddBrand'
 import EditBrandPage from '@/features/brands/pages/EditBrand'
 
 import DetailBrandPage from '@/features/brands/pages/DetailBrand'
+import ListCategoriesPage from '@/features/categories/pages/ListCategories'
+import AddCategoryPage from '@/features/categories/pages/AddCategory'
+import EditCategoryPage from '@/features/categories/pages/EditCategory'
+import DetailCategoryPage from '@/features/categories/pages/DetailCategory'
 
 export const router = createBrowserRouter([
     {
@@ -28,6 +32,11 @@ export const router = createBrowserRouter([
                     { path: ROUTES.BRAND.NEW, element: <AddBrandPage /> },
                     { path: ROUTES.BRAND.DETAIL(), element: <DetailBrandPage /> },
                     { path: ROUTES.BRAND.EDIT(), element: <EditBrandPage /> },
+
+                    { path: ROUTES.CATEGORY.LIST, element: <ListCategoriesPage /> },
+                    { path: ROUTES.CATEGORY.NEW, element: <AddCategoryPage /> },
+                    { path: ROUTES.CATEGORY.DETAIL(), element: <DetailCategoryPage /> },
+                    { path: ROUTES.CATEGORY.EDIT(), element: <EditCategoryPage /> },
                 ],
             },
             { path: ROUTES.LOGIN, element: <LoginPage /> },

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -12,4 +12,11 @@ export const ROUTES = {
         DETAIL: (id = ':id') => `/brands/${id}`,
         EDIT: (id = ':id') => `/brands/${id}/edit`,
     },
+    // Category
+    CATEGORY: {
+        LIST: '/categories',
+        NEW: '/categories/new',
+        DETAIL: (id = ':id') => `/categories/${id}`,
+        EDIT: (id = ':id') => `/categories/${id}/edit`,
+    },
 } as const

--- a/src/features/categories/components/layout/Form/CategoryForm.tsx
+++ b/src/features/categories/components/layout/Form/CategoryForm.tsx
@@ -1,0 +1,191 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import * as React from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.tsx'
+import { Input } from '@/components/ui/input.tsx'
+import { Label } from '@/components/ui/label.tsx'
+import { useI18n } from '@/shared/hooks/useI18n.ts'
+import type { CreateCategoryRequest } from '@/features/categories/model/types'
+
+type Props = Readonly<{
+    defaultValues?: Partial<CreateCategoryRequest>
+    onSubmit: (data: CreateCategoryRequest) => void
+    submitting?: boolean
+    formId?: string
+    apiErrors?: ReadonlyArray<{ field: string; message: string }>
+}>
+
+function normalizeUrl(value: string): string {
+    const trimmed = value.trim()
+    if (!trimmed) return ''
+    const hasProtocol = /^(https?:)?\/\//i.test(trimmed)
+    const candidate = hasProtocol ? trimmed : `https://${trimmed}`
+    try {
+        return new URL(candidate).toString()
+    } catch {
+        return trimmed
+    }
+}
+function isLenientValidUrl(value: string): true | string {
+    if (!value) return true
+    const candidate = /^(https?:)?\/\//i.test(value) ? value : `https://${value}`
+    try {
+        new URL(candidate)
+        return true
+    } catch {
+        return 'validation.url'
+    }
+}
+
+export default function CategoryForm({
+    defaultValues,
+    onSubmit,
+    submitting = false,
+    formId = 'category-form',
+    apiErrors,
+}: Props) {
+    const { t } = useI18n()
+
+    const schema = React.useMemo(
+        () =>
+            z.object({
+                name: z
+                    .string()
+                    .trim()
+                    .min(1, t('validation.required'))
+                    .max(120, t('validation.max_length', { n: 120 })),
+                description: z
+                    .union([z.string().max(500, t('validation.max_length', { n: 500 })), z.literal('')])
+                    .optional(),
+                parent_id: z.union([z.string(), z.literal('')]).optional(),
+                image_url: z
+                    .union([z.string().max(2048, t('validation.max_length', { n: 2048 })), z.literal('')])
+                    .optional()
+                    .refine((v) => !v || isLenientValidUrl(v) === true, t('validation.url')),
+            }),
+        [t],
+    )
+
+    const form = useForm<CreateCategoryRequest>({
+        resolver: zodResolver(schema),
+        defaultValues: {
+            name: '',
+            description: '',
+            parent_id: '',
+            image_url: '',
+            ...defaultValues,
+        },
+        mode: 'onBlur',
+    })
+
+    const { handleSubmit, reset, setError } = form
+
+    React.useEffect(() => {
+        if (defaultValues) {
+            reset({
+                name: defaultValues.name ?? '',
+                description: defaultValues.description ?? '',
+                parent_id: defaultValues.parent_id ?? '',
+                image_url: defaultValues.image_url ?? '',
+            })
+        }
+    }, [defaultValues, reset])
+
+    React.useEffect(() => {
+        if (!apiErrors || apiErrors.length === 0) return
+        apiErrors.forEach((err) => {
+            const path = err.field?.split('.')?.pop() ?? err.field
+            if (path === 'name' || path === 'description' || path === 'parent_id' || path === 'image_url') {
+                setError(path as keyof CreateCategoryRequest, { type: 'server', message: err.message })
+            }
+        })
+    }, [apiErrors, setError])
+
+    return (
+        <FormProvider {...form}>
+            <form
+                id={formId}
+                noValidate
+                className="grid gap-6"
+                onSubmit={handleSubmit((values) => {
+                    const cleaned: CreateCategoryRequest = {
+                        name: values.name.trim(),
+                        description: values.description?.trim() || '',
+                        parent_id: values.parent_id?.trim() || '',
+                        image_url: values.image_url ? normalizeUrl(values.image_url) : '',
+                    }
+                    onSubmit(cleaned)
+                })}
+            >
+                <Card className="overflow-hidden shadow-sm">
+                    <CardHeader className="bg-muted/50">
+                        <CardTitle className="text-lg font-semibold">
+                            {t('categories.form.title')}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-4 p-6">
+                        <div>
+                            <Label htmlFor="category-name">{t('categories.form.name')}*</Label>
+                            <Input
+                                id="category-name"
+                                placeholder={t('categories.form.name_ph') as string}
+                                autoComplete="off"
+                                aria-invalid={Boolean(form.formState.errors.name)}
+                                {...form.register('name')}
+                            />
+                            {form.formState.errors.name && (
+                                <p className="mt-1 text-xs text-destructive">
+                                    {form.formState.errors.name.message}
+                                </p>
+                            )}
+                        </div>
+                        <div>
+                            <Label htmlFor="category-description">{t('categories.form.description')}</Label>
+                            <textarea
+                                id="category-description"
+                                placeholder={t('categories.form.description_ph') as string}
+                                className="min-h-24 w-full resize-vertical rounded-md border bg-background px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50"
+                                aria-invalid={Boolean(form.formState.errors.description)}
+                                {...form.register('description')}
+                            />
+                            {form.formState.errors.description && (
+                                <p className="mt-1 text-xs text-destructive">
+                                    {form.formState.errors.description.message}
+                                </p>
+                            )}
+                        </div>
+                        <div>
+                            <Label htmlFor="category-parent">{t('categories.form.parent_id')}</Label>
+                            <Input
+                                id="category-parent"
+                                placeholder={t('categories.form.parent_id_ph') as string}
+                                aria-invalid={Boolean(form.formState.errors.parent_id)}
+                                {...form.register('parent_id')}
+                            />
+                            {form.formState.errors.parent_id && (
+                                <p className="mt-1 text-xs text-destructive">
+                                    {form.formState.errors.parent_id.message}
+                                </p>
+                            )}
+                        </div>
+                        <div>
+                            <Label htmlFor="category-image">{t('categories.form.image_url')}</Label>
+                            <Input
+                                id="category-image"
+                                placeholder={t('categories.form.image_url_ph') as string}
+                                aria-invalid={Boolean(form.formState.errors.image_url)}
+                                {...form.register('image_url')}
+                            />
+                            {form.formState.errors.image_url && (
+                                <p className="mt-1 text-xs text-destructive">
+                                    {form.formState.errors.image_url.message}
+                                </p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </form>
+        </FormProvider>
+    )
+}

--- a/src/features/categories/components/layout/Table/CategoriesTable.tsx
+++ b/src/features/categories/components/layout/Table/CategoriesTable.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react'
+import { JSX } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { MoreVertical, Pencil, Trash2 } from 'lucide-react'
+
+import { ROUTES } from '@/app/routes/routes'
+import { Button } from '@/components/ui/button'
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@/components/ui/table'
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { CategoryData } from '@/features/categories/model/types'
+
+type Props = Readonly<{
+    items: ReadonlyArray<CategoryData>
+    onDelete: (id: string) => void
+}>
+
+export default function CategoriesTable({ items, onDelete }: Props): JSX.Element {
+    const { t } = useI18n()
+    const navigate = useNavigate()
+
+    const goDetail = React.useCallback(
+        (id: string) => navigate(ROUTES.CATEGORY.DETAIL(id)),
+        [navigate],
+    )
+    const goEdit = React.useCallback(
+        (id: string) => navigate(ROUTES.CATEGORY.EDIT(id)),
+        [navigate],
+    )
+
+    return (
+        <div className="relative overflow-hidden rounded-lg border">
+            <Table>
+                <TableHeader className="sticky top-0 z-10 bg-muted/50 backdrop-blur supports-[backdrop-filter]:bg-muted/40">
+                    <TableRow className="h-10">
+                        <TableHead className="px-3 text-xs font-medium text-muted-foreground">
+                            {t('categories.table.name')}
+                        </TableHead>
+                        <TableHead className="px-3 text-xs font-medium text-muted-foreground">
+                            {t('categories.table.parent')}
+                        </TableHead>
+                        <TableHead className="w-16 px-3 text-right text-xs font-medium text-muted-foreground">
+                            {t('categories.table.actions')}
+                        </TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {items.map((c) => (
+                        <TableRow
+                            key={c.id}
+                            className="h-12 cursor-pointer hover:bg-muted/40 focus-visible:bg-muted/40"
+                            onClick={() => goDetail(c.id)}
+                            tabIndex={0}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault()
+                                    goDetail(c.id)
+                                }
+                            }}
+                        >
+                            <TableCell className="px-3 py-2.5 font-medium">
+                                {c.name}
+                            </TableCell>
+                            <TableCell className="px-3 py-2.5">
+                                {c.parent_id ?? '-'}
+                            </TableCell>
+                            <TableCell className="px-3 py-2.5 text-right">
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="size-8 p-0"
+                                            onClick={(e) => e.stopPropagation()}
+                                            aria-label={t('common.more_actions') as string}
+                                        >
+                                            <MoreVertical className="size-4" />
+                                        </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                        align="end"
+                                        sideOffset={6}
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        <DropdownMenuItem onClick={() => goEdit(c.id)}>
+                                            <Pencil className="mr-2 size-4" />
+                                            {t('categories.actions.edit')}
+                                        </DropdownMenuItem>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem
+                                            className="text-destructive focus:text-destructive"
+                                            onClick={() => onDelete(c.id)}
+                                        >
+                                            <Trash2 className="mr-2 size-4" />
+                                            {t('categories.actions.delete')}
+                                        </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    )
+}

--- a/src/features/categories/components/ui/Pagination.tsx
+++ b/src/features/categories/components/ui/Pagination.tsx
@@ -1,0 +1,155 @@
+import * as React from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from "lucide-react"
+import { useI18n } from "@/shared/hooks/useI18n"
+import { convertDigitsByLocale } from "@/shared/i18n/numbers"
+
+export type PaginationProps = {
+    page: number
+    pages: number
+    hasPrev: boolean
+    hasNext: boolean
+    disabled?: boolean
+    onFirst: () => void
+    onPrev: () => void
+    onNext: () => void
+    onLast: () => void
+    labels: {
+        first: string
+        prev: string
+        next: string
+        last: string
+        rowsPerPage: string
+        page: string
+        of: string
+    }
+    pageSize?: number
+    pageSizeOptions?: number[]
+    onPageSizeChange?: (size: number) => void
+}
+
+function useIsRTL() {
+    const [rtl, setRtl] = React.useState(false)
+    React.useEffect(() => {
+        const el = document?.documentElement
+        const update = () => setRtl(el?.getAttribute("dir") === "rtl")
+        update()
+        const obs = new MutationObserver(update)
+        if (el) obs.observe(el, { attributes: true, attributeFilter: ["dir"] })
+        return () => obs.disconnect()
+    }, [])
+    return rtl
+}
+
+export default function Pagination({
+                                       page,
+                                       pages,
+                                       hasPrev,
+                                       hasNext,
+                                       disabled,
+                                       onFirst,
+                                       onPrev,
+                                       onNext,
+                                       onLast,
+                                       labels,
+                                       pageSize,
+                                       pageSizeOptions = [10, 20, 30, 40, 50],
+                                       onPageSizeChange,
+                                   }: PaginationProps) {
+    const isRTL = useIsRTL()
+    const { locale } = useI18n()
+    const d = React.useCallback((v: number | string) => convertDigitsByLocale(v, locale), [locale])
+
+    const totalPages = Math.max(0, pages)
+    const currentPage = totalPages === 0 ? 0 : Math.min(page + 1, totalPages)
+    const allDisabled = !!disabled
+    const showRowsPerPage = typeof pageSize === "number" && !!onPageSizeChange
+
+    return (
+        <div className="flex w-full flex-wrap items-center justify-between gap-3 p-3">
+            <div className="flex items-center gap-2">
+                {showRowsPerPage && (
+                    <>
+                        <Label htmlFor="rows-per-page" className="hidden text-sm font-medium sm:inline">
+                            {labels.rowsPerPage}
+                        </Label>
+                        <Select
+                            value={`${pageSize}`}
+                            onValueChange={(v: string) => onPageSizeChange?.(Number(v))}
+                            disabled={allDisabled}
+                        >
+                            <SelectTrigger id="rows-per-page" size="sm" className="w-20">
+                                <SelectValue placeholder={d(pageSize ?? "")} />
+                            </SelectTrigger>
+                            <SelectContent side="top">
+                                {pageSizeOptions.map((ps) => (
+                                    <SelectItem key={ps} value={`${ps}`}>
+                                        {d(ps)}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </>
+                )}
+            </div>
+
+            <div className="flex items-center gap-6">
+                <div className="text-sm font-medium" aria-live="polite">
+                    {labels.page} {d(currentPage)} {labels.of} {d(totalPages)}
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="hidden h-8 w-8 p-0 lg:flex"
+                        onClick={onFirst}
+                        disabled={!hasPrev || allDisabled}
+                        aria-label={labels.first}
+                        title={labels.first}
+                    >
+                        <ChevronsLeft className={`h-4 w-4 ${isRTL ? "-scale-x-100" : ""}`} />
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8 p-0"
+                        onClick={onPrev}
+                        disabled={!hasPrev || allDisabled}
+                        aria-label={labels.prev}
+                        title={labels.prev}
+                    >
+                        <ChevronLeft className={`h-4 w-4 ${isRTL ? "-scale-x-100" : ""}`} />
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8 p-0"
+                        onClick={onNext}
+                        disabled={!hasNext || allDisabled}
+                        aria-label={labels.next}
+                        title={labels.next}
+                    >
+                        <ChevronRight className={`h-4 w-4 ${isRTL ? "-scale-x-100" : ""}`} />
+                    </Button>
+
+                    <Button
+                        variant="outline"
+                        size="icon"
+                        className="hidden h-8 w-8 p-0 lg:flex"
+                        onClick={onLast}
+                        disabled={!hasNext || allDisabled}
+                        aria-label={labels.last}
+                        title={labels.last}
+                    >
+                        <ChevronsRight className={`h-4 w-4 ${isRTL ? "-scale-x-100" : ""}`} />
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/features/categories/index.ts
+++ b/src/features/categories/index.ts
@@ -1,0 +1,15 @@
+import { catalogClient } from '@/lib/axios'
+import { API_ROUTES } from '@/shared/constants/apiRoutes'
+import { createCrudApi } from '@/shared/api/crudFactory'
+import { createCrudHooks } from '@/shared/api/useCrudQueries'
+import type { CategoryData, CreateCategoryRequest, UpdateCategoryRequest } from './model/types'
+
+export const categoriesApi = createCrudApi<CategoryData, CreateCategoryRequest, UpdateCategoryRequest>(
+    catalogClient,
+    API_ROUTES.CATEGORIES.ROOT,
+)
+
+export const categoriesQueries = createCrudHooks<CategoryData, CreateCategoryRequest, UpdateCategoryRequest>(
+    'category',
+    categoriesApi,
+)

--- a/src/features/categories/model/types.ts
+++ b/src/features/categories/model/types.ts
@@ -1,0 +1,23 @@
+import type { ApiResponse } from '@/shared/api/types'
+
+export interface CategoryData {
+    id: string
+    name: string
+    description?: string | null
+    image_url?: string | null
+    parent_id?: string | null
+    created_at: string
+    updated_at: string
+}
+
+export interface CreateCategoryRequest {
+    name: string
+    description?: string
+    parent_id?: string
+    image_url?: string
+}
+
+export type UpdateCategoryRequest = Partial<CreateCategoryRequest>
+
+export type CategoryResponse = ApiResponse<CategoryData>
+export type CategoryListResponse = ApiResponse<CategoryData[]>

--- a/src/features/categories/pages/AddCategory/AddCategoryPage.tsx
+++ b/src/features/categories/pages/AddCategory/AddCategoryPage.tsx
@@ -1,0 +1,78 @@
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { toast } from 'sonner'
+import * as React from 'react'
+import { JSX } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { ROUTES } from '@/app/routes/routes'
+import { Button } from '@/components/ui/button'
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import CategoryForm from '@/features/categories/components/layout/Form/CategoryForm'
+import type { CreateCategoryRequest } from '@/features/categories/model/types'
+import { useI18n } from '@/shared/hooks/useI18n'
+import { isRTLLocale } from '@/shared/i18n/utils'
+import { categoriesQueries } from '@/features/categories'
+
+const FORM_ID = 'category-form'
+
+export default function AddCategoryPage(): JSX.Element {
+    const navigate = useNavigate()
+    const { t, locale } = useI18n()
+    const rtl = isRTLLocale(locale)
+
+    const createMutation = categoriesQueries.useCreate()
+    const [apiErrors, setApiErrors] = React.useState<ReadonlyArray<{ field: string; message: string }>>([])
+
+    function handleSubmit(values: CreateCategoryRequest) {
+        setApiErrors([])
+        createMutation.mutate(values, {
+            onSuccess: () => {
+                toast.success(t('categories.saved_success'))
+                navigate(ROUTES.CATEGORY.LIST)
+            },
+            onError: (err) => {
+                const resp = (err as { response?: { data?: unknown } }).response?.data as
+                    | { code?: number; errors?: Array<{ field: string; message: string }> }
+                    | undefined
+                if (resp?.code === 422 && Array.isArray(resp.errors)) {
+                    setApiErrors(resp.errors)
+                } else {
+                    toast.error(t('common.error'))
+                }
+            },
+        })
+    }
+
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={() => navigate(-1)}
+                            aria-label={t('common.back')}
+                            title={t('common.back')}
+                        >
+                            {rtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">{t('categories.add')}</h1>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button type="submit" form={FORM_ID} disabled={createMutation.isPending}>
+                            {createMutation.isPending ? t('common.saving') : t('common.save')}
+                        </Button>
+                    </div>
+                </div>
+                <CategoryForm
+                    formId={FORM_ID}
+                    onSubmit={handleSubmit}
+                    submitting={createMutation.isPending}
+                    apiErrors={apiErrors}
+                />
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/categories/pages/AddCategory/index.ts
+++ b/src/features/categories/pages/AddCategory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddCategoryPage'

--- a/src/features/categories/pages/DetailCategory/DetailCategoryPage.tsx
+++ b/src/features/categories/pages/DetailCategory/DetailCategoryPage.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, ArrowRight, Pencil } from 'lucide-react'
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import { Button } from '@/components/ui/button'
+import { useI18n } from '@/shared/hooks/useI18n'
+import { isRTLLocale } from '@/shared/i18n/utils'
+import { categoriesQueries } from '@/features/categories'
+import ErrorFallback from '@/components/layout/ErrorFallback'
+import { ROUTES } from '@/app/routes/routes'
+
+export default function DetailCategoryPage() {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+    const { t, locale } = useI18n()
+    const rtl = isRTLLocale(locale)
+
+    const detailQuery = categoriesQueries.useDetail(id!)
+
+    if (detailQuery.isLoading) {
+        return (
+            <DashboardLayout>
+                <div className="p-6">{t('common.loading')}</div>
+            </DashboardLayout>
+        )
+    }
+    if (detailQuery.isError || !detailQuery.data) {
+        return (
+            <DashboardLayout>
+                <ErrorFallback error={detailQuery.error} onRetry={() => detailQuery.refetch()} />
+            </DashboardLayout>
+        )
+    }
+
+    const c = detailQuery.data.data
+
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={() => navigate(-1)}
+                            aria-label={t('common.back')}
+                            title={t('common.back')}
+                        >
+                            {rtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">{c.name}</h1>
+                    </div>
+                    <Button onClick={() => navigate(ROUTES.CATEGORY.EDIT(c.id))}>
+                        <Pencil className="mr-2 h-4 w-4" /> {t('categories.actions.edit')}
+                    </Button>
+                </div>
+                <div className="grid gap-2">
+                    <div>
+                        <span className="font-semibold">{t('categories.form.description')}: </span>
+                        <span>{c.description || '-'}</span>
+                    </div>
+                    <div>
+                        <span className="font-semibold">{t('categories.form.parent_id')}: </span>
+                        <span>{c.parent_id || '-'}</span>
+                    </div>
+                    <div>
+                        <span className="font-semibold">{t('categories.form.image_url')}: </span>
+                        {c.image_url ? (
+                            <a
+                                href={c.image_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-primary underline"
+                            >
+                                {c.image_url}
+                            </a>
+                        ) : (
+                            <span>-</span>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/categories/pages/DetailCategory/index.ts
+++ b/src/features/categories/pages/DetailCategory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DetailCategoryPage'

--- a/src/features/categories/pages/EditCategory/EditCategoryPage.tsx
+++ b/src/features/categories/pages/EditCategory/EditCategoryPage.tsx
@@ -1,0 +1,126 @@
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { toast } from 'sonner'
+import * as React from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { ROUTES } from '@/app/routes/routes'
+import { Button } from '@/components/ui/button'
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import CategoryForm from '@/features/categories/components/layout/Form/CategoryForm'
+import type { CreateCategoryRequest, UpdateCategoryRequest } from '@/features/categories/model/types'
+import { useI18n } from '@/shared/hooks/useI18n'
+import { isRTLLocale } from '@/shared/i18n/utils'
+import { categoriesQueries } from '@/features/categories'
+import ErrorFallback from '@/components/layout/ErrorFallback'
+
+const FORM_ID = 'category-form'
+
+export default function EditCategoryPage() {
+    const { id } = useParams<{ id: string }>()
+    const navigate = useNavigate()
+    const { t, locale } = useI18n()
+    const rtl = isRTLLocale(locale)
+
+    const detailQuery = categoriesQueries.useDetail(id!)
+    const updateMutation = categoriesQueries.useUpdate()
+    const deleteMutation = categoriesQueries.useDelete()
+    const [apiErrors, setApiErrors] = React.useState<ReadonlyArray<{ field: string; message: string }>>([])
+
+    const handleSubmit = (values: CreateCategoryRequest) => {
+        if (!id) return
+        setApiErrors([])
+        const payload: UpdateCategoryRequest = values
+        updateMutation.mutate({ id, payload }, {
+            onSuccess: () => {
+                toast.success(t('categories.saved_success'))
+                navigate(ROUTES.CATEGORY.LIST)
+            },
+            onError: (err) => {
+                const resp = (err as { response?: { data?: unknown } }).response?.data as
+                    | { code?: number; errors?: Array<{ field: string; message: string }> }
+                    | undefined
+                if (resp?.code === 422 && Array.isArray(resp.errors)) {
+                    setApiErrors(resp.errors)
+                } else {
+                    toast.error(t('common.error'))
+                }
+            },
+        })
+    }
+
+    const handleDelete = () => {
+        if (!id) return
+        if (!window.confirm(t('categories.actions.delete_confirm') as string)) return
+        deleteMutation.mutate(id, {
+            onSuccess: () => {
+                toast.success(t('categories.deleted'))
+                navigate(ROUTES.CATEGORY.LIST)
+            },
+            onError: () => toast.error(t('common.error')),
+        })
+    }
+
+    if (detailQuery.isLoading) {
+        return (
+            <DashboardLayout>
+                <div className="p-6">{t('common.loading')}</div>
+            </DashboardLayout>
+        )
+    }
+    if (detailQuery.isError || !detailQuery.data) {
+        return (
+            <DashboardLayout>
+                <ErrorFallback error={detailQuery.error} onRetry={() => detailQuery.refetch()} />
+            </DashboardLayout>
+        )
+    }
+
+    const defaults: CreateCategoryRequest = {
+        name: detailQuery.data.data.name,
+        description: detailQuery.data.data.description || '',
+        parent_id: detailQuery.data.data.parent_id || '',
+        image_url: detailQuery.data.data.image_url || '',
+    }
+
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={() => navigate(-1)}
+                            aria-label={t('common.back')}
+                            title={t('common.back')}
+                        >
+                            {rtl ? <ArrowRight className="h-4 w-4" /> : <ArrowLeft className="h-4 w-4" />}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">{t('categories.edit')}</h1>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={handleDelete}
+                            disabled={deleteMutation.isPending}
+                        >
+                            {t('categories.actions.delete')}
+                        </Button>
+                        <Button type="submit" form={FORM_ID} disabled={updateMutation.isPending}>
+                            {updateMutation.isPending ? t('common.saving') : t('common.save')}
+                        </Button>
+                    </div>
+                </div>
+                <CategoryForm
+                    formId={FORM_ID}
+                    onSubmit={handleSubmit}
+                    submitting={updateMutation.isPending}
+                    defaultValues={defaults}
+                    apiErrors={apiErrors}
+                />
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/categories/pages/EditCategory/index.ts
+++ b/src/features/categories/pages/EditCategory/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EditCategoryPage'

--- a/src/features/categories/pages/ListCategories/ListCategoriesPage.tsx
+++ b/src/features/categories/pages/ListCategories/ListCategoriesPage.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react'
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import { useListCategoriesPage } from './useListCategoriesPage'
+import CategoriesTable from '@/features/categories/components/layout/Table/CategoriesTable'
+import Pagination from '@/features/categories/components/ui/Pagination'
+import ErrorFallback from '@/components/layout/ErrorFallback'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Search } from 'lucide-react'
+
+export default function ListCategoriesPage() {
+    const {
+        nav,
+        i18n: { t },
+        queryState,
+        list,
+        status,
+        actions,
+    } = useListCategoriesPage()
+
+    const subtitle =
+        list.total > 0
+            ? (t('common.showing_count', { count: list.total }) as string)
+            : (t('common.search_hint') as string)
+
+    const content = () => {
+        if (status.isError) {
+            return <ErrorFallback error={status.error} onRetry={() => actions.refetch()} />
+        }
+        if (status.isLoading) return <div>{t('common.loading')}</div>
+        if (list.items.length === 0) return <div>{t('common.no_results')}</div>
+        return <CategoriesTable items={list.items} onDelete={actions.handleDelete} />
+    }
+
+    const paginationNode =
+        status.isLoading || list.items.length === 0 ? null : (
+            <Pagination
+                page={queryState.page}
+                pages={list.totalPages}
+                hasPrev={list.hasPrev}
+                hasNext={list.hasNext}
+                disabled={status.isLoading}
+                onFirst={actions.goFirst}
+                onPrev={actions.goPrev}
+                onNext={actions.goNext}
+                onLast={actions.goLast}
+                pageSize={queryState.pageSize}
+                pageSizeOptions={[5, 10, 20, 30, 50]}
+                onPageSizeChange={queryState.setPageSize}
+                labels={{
+                    first: t('pagination.first') as string,
+                    prev: t('pagination.prev') as string,
+                    next: t('pagination.next') as string,
+                    last: t('pagination.last') as string,
+                    rowsPerPage: t('pagination.rowsPerPage') as string,
+                    page: t('pagination.page') as string,
+                    of: t('pagination.of') as string,
+                }}
+            />
+        )
+
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 py-4 md:gap-6 md:py-6">
+                <div className="flex items-center justify-between px-4 lg:px-6">
+                    <div className="flex flex-col">
+                        <h1 className="text-2xl font-bold">{t('categories.title')}</h1>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <div className="relative">
+                            <Search
+                                aria-hidden="true"
+                                className="pointer-events-none absolute top-1/2 -translate-y-1/2 size-4 text-muted-foreground [inset-inline-start:0.625rem]"
+                            />
+                            <Input
+                                value={queryState.query}
+                                onChange={(e) => {
+                                    queryState.setQuery(e.target.value)
+                                    queryState.setPage(0)
+                                }}
+                                placeholder={t('categories.search_placeholder') as string}
+                                aria-label={t('categories.search_placeholder') as string}
+                                className="w-72 [padding-inline-start:2rem]"
+                            />
+                        </div>
+                        <Button onClick={() => nav.navigate(nav.ROUTES.CATEGORY.NEW)}>
+                            {t('categories.create')}
+                        </Button>
+                    </div>
+                </div>
+                {subtitle && (
+                    <div className="px-4 lg:px-6 -mt-2">
+                        <p className="text-sm text-muted-foreground">{subtitle}</p>
+                    </div>
+                )}
+                <div className="px-4 lg:px-6">
+                    <div className={status.isFetching ? 'relative' : ''}>
+                        {status.isFetching && <div className="absolute inset-0 rounded-lg bg-background/40" />}
+                        {content()}
+                    </div>
+                </div>
+                {paginationNode && <div className="px-4 lg:px-6">{paginationNode}</div>}
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/categories/pages/ListCategories/index.ts
+++ b/src/features/categories/pages/ListCategories/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListCategoriesPage'

--- a/src/features/categories/pages/ListCategories/useListCategoriesPage.ts
+++ b/src/features/categories/pages/ListCategories/useListCategoriesPage.ts
@@ -1,0 +1,120 @@
+import { useMemo, useState, useCallback, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { toast } from 'sonner'
+
+import { categoriesQueries } from '@/features/categories'
+import type { CategoryData, CreateCategoryRequest } from '@/features/categories/model/types'
+import { ROUTES } from '@/app/routes/routes'
+import useDebounced from '@/shared/hooks/useDebounced'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { PaginationProps } from '@/features/categories/components/ui/Pagination'
+
+export function useListCategoriesPage() {
+    const { t } = useI18n()
+    const navigate = useNavigate()
+
+    const [page, setPage] = useState(0)
+    const [pageSize, setPageSize] = useState(10)
+    const [query, setQuery] = useState('')
+    const debouncedQuery = useDebounced(query, 450)
+
+    const listParams = useMemo(
+        () => ({ page: page + 1, limit: pageSize, name: debouncedQuery }),
+        [page, pageSize, debouncedQuery],
+    )
+
+    const { data, isLoading, isFetching, isError, error, refetch } =
+        categoriesQueries.useList(listParams)
+
+    const items: CategoryData[] = data?.data ?? []
+    const pagination = data?.meta?.pagination
+    const total = pagination?.total ?? items.length
+    const totalPagesFromApi = pagination?.total_pages
+
+    const totalPages = useMemo(
+        () => Math.max(1, totalPagesFromApi ?? Math.ceil(total / pageSize)),
+        [totalPagesFromApi, total, pageSize],
+    )
+
+    const hasPrev = pagination?.has_previous ?? page > 0
+    const hasNext = pagination?.has_next ?? page + 1 < totalPages
+
+    useEffect(() => {
+        setPage(0)
+    }, [debouncedQuery, pageSize])
+
+    useEffect(() => {
+        setPage((p) => Math.min(p, Math.max(0, totalPages - 1)))
+    }, [totalPages])
+
+    const deleteMutation = categoriesQueries.useDelete()
+    const createMutation = categoriesQueries.useCreate()
+
+    const handleDelete = useCallback(
+        (id: string) => {
+            const toDelete = items.find((x) => x.id === id) || null
+            deleteMutation.mutate(id, {
+                onSuccess: () => {
+                    toast(t('categories.deleted'), {
+                        action: {
+                            label: t('common.undo'),
+                            onClick: () => {
+                                if (!toDelete) return
+                                const payload: CreateCategoryRequest = {
+                                    name: toDelete.name,
+                                    description: toDelete.description || '',
+                                    parent_id: toDelete.parent_id || '',
+                                    image_url: toDelete.image_url || '',
+                                }
+                                createMutation.mutate(payload, {
+                                    onSuccess: () => {
+                                        toast.success(t('common.restored'))
+                                        void refetch()
+                                    },
+                                    onError: () => toast.error(t('common.error')),
+                                })
+                            },
+                        },
+                    })
+                    void refetch()
+                },
+                onError: () => {
+                    toast.error(t('common.error'))
+                },
+            })
+        },
+        [createMutation, deleteMutation, items, refetch, t],
+    )
+
+    const goFirst = useCallback(() => setPage(0), [])
+    const goPrev = useCallback(() => setPage((p) => Math.max(0, p - 1)), [])
+    const goNext = useCallback(
+        () => setPage((p) => Math.min(Math.max(0, totalPages - 1), p + 1)),
+        [totalPages],
+    )
+    const goLast = useCallback(() => setPage(Math.max(0, totalPages - 1)), [totalPages])
+
+    const paginationProps: Omit<PaginationProps, 'labels'> = {
+        page,
+        pages: totalPages,
+        hasPrev,
+        hasNext,
+        onFirst: goFirst,
+        onPrev: goPrev,
+        onNext: goNext,
+        onLast: goLast,
+        pageSize,
+        pageSizeOptions: [5, 10, 20, 30, 50],
+        onPageSizeChange: setPageSize,
+    }
+
+    return {
+        nav: { navigate, ROUTES },
+        i18n: { t },
+        queryState: { query, setQuery, page, setPage, pageSize, setPageSize },
+        list: { items, total, totalPages, hasPrev, hasNext },
+        status: { isLoading, isFetching, isError, error },
+        actions: { refetch, handleDelete, goFirst, goPrev, goNext, goLast },
+        ui: { pagination: paginationProps },
+    }
+}

--- a/src/features/sidebar/app-sidebar.tsx
+++ b/src/features/sidebar/app-sidebar.tsx
@@ -48,7 +48,10 @@ const itemsSchema: MenuItem[] = [
     {
         titleKey: "menu.basic",
         icon: SettingsIcon,
-        children: [{ titleKey: "menu.basic.brand", url: ROUTES.BRAND.LIST }],
+        children: [
+            { titleKey: "menu.basic.brand", url: ROUTES.BRAND.LIST },
+            { titleKey: "menu.basic.category", url: ROUTES.CATEGORY.LIST },
+        ],
     },
 ]
 

--- a/src/shared/constants/apiRoutes.ts
+++ b/src/shared/constants/apiRoutes.ts
@@ -21,6 +21,9 @@ export const API_ROUTES = {
     BRANDS: {
         ROOT: '/brands',
     },
+    CATEGORIES: {
+        ROOT: '/categories',
+    },
 } as const
 
 export type ApiRoute = typeof API_ROUTES

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -25,6 +25,7 @@
 
   "menu.basic": "Basic",
   "menu.basic.brand": "Brands",
+  "menu.basic.category": "Categories",
 
   "user.guest": "Guest",
 
@@ -36,6 +37,14 @@
   "brands.title": "Brands",
   "brands.create": "Add Brand",
   "brands.search_placeholder": "Search brands...",
+
+  "categories.saved_success": "Category saved successfully",
+  "categories.add": "Add Category",
+  "categories.edit": "Edit Category",
+  "categories.deleted": "Category deleted",
+  "categories.title": "Categories",
+  "categories.create": "Add Category",
+  "categories.search_placeholder": "Search categories...",
 
   "common.error": "Something went wrong",
   "common.back": "Back",
@@ -73,6 +82,16 @@
   "brands.form.logo": "Logo",
   "brands.form.logo_help": "Upload the brand logo (recommended square format)",
 
+  "categories.form.title": "Category Information",
+  "categories.form.name": "Name",
+  "categories.form.name_ph": "Enter category name",
+  "categories.form.description": "Description",
+  "categories.form.description_ph": "Enter description",
+  "categories.form.parent_id": "Parent ID",
+  "categories.form.parent_id_ph": "Enter parent category ID",
+  "categories.form.image_url": "Image URL",
+  "categories.form.image_url_ph": "Enter image URL",
+
   "validation.required": "This field is required",
   "validation.min_length": "Must be at least {n} characters",
   "validation.max_length": "Must be at most {n} characters",
@@ -83,6 +102,14 @@
   "brands.table.country": "Country",
   "brands.table.website": "Website",
   "brands.table.actions": "Actions",
+
+  "categories.table.name": "Name",
+  "categories.table.parent": "Parent",
+  "categories.table.actions": "Actions",
+
+  "categories.actions.edit": "Edit",
+  "categories.actions.delete": "Delete",
+  "categories.actions.delete_confirm": "Are you sure you want to delete this category? This action cannot be undone.",
 
   "uploader.errors.type_image_only": "Only image files are allowed",
   "uploader.errors.max_size": "Max file size is {size}MB",

--- a/src/shared/i18n/locales/fa.json
+++ b/src/shared/i18n/locales/fa.json
@@ -25,6 +25,7 @@
 
   "menu.basic": "پایه",
   "menu.basic.brand": "برندها",
+  "menu.basic.category": "دسته‌ها",
 
   "user.guest": "مهمان",
 
@@ -36,6 +37,14 @@
   "brands.title": "برندها",
   "brands.create": "ایجاد برند",
   "brands.search_placeholder": "جستجوی برند...",
+
+  "categories.saved_success": "دسته با موفقیت ذخیره شد",
+  "categories.add": "افزودن دسته",
+  "categories.edit": "ویرایش دسته",
+  "categories.deleted": "دسته حذف شد",
+  "categories.title": "دسته‌ها",
+  "categories.create": "افزودن دسته",
+  "categories.search_placeholder": "جستجوی دسته...",
 
   "common.error": "مشکلی پیش آمد",
   "common.back": "بازگشت",
@@ -73,6 +82,16 @@
   "brands.form.logo": "لوگو",
   "brands.form.logo_help": "لوگوی برند را بارگذاری کنید (ترجیحاً مربع باشد)",
 
+  "categories.form.title": "اطلاعات دسته",
+  "categories.form.name": "نام",
+  "categories.form.name_ph": "نام دسته را وارد کنید",
+  "categories.form.description": "توضیحات",
+  "categories.form.description_ph": "توضیحات را وارد کنید",
+  "categories.form.parent_id": "شناسه والد",
+  "categories.form.parent_id_ph": "شناسه دسته والد را وارد کنید",
+  "categories.form.image_url": "آدرس تصویر",
+  "categories.form.image_url_ph": "آدرس تصویر را وارد کنید",
+
   "validation.required": "این فیلد الزامی است",
   "validation.min_length": "حداقل باید {n} کاراکتر باشد",
   "validation.max_length": "حداکثر باید {n} کاراکتر باشد",
@@ -83,6 +102,14 @@
   "brands.table.country": "کشور",
   "brands.table.website": "وب‌سایت",
   "brands.table.actions": "عملیات",
+
+  "categories.table.name": "نام",
+  "categories.table.parent": "والد",
+  "categories.table.actions": "عملیات",
+
+  "categories.actions.edit": "ویرایش",
+  "categories.actions.delete": "حذف",
+  "categories.actions.delete_confirm": "آیا از حذف این دسته مطمئن هستید؟ این عمل قابل بازگشت نیست.",
 
   "uploader.errors.type_image_only": "فقط فایل‌های تصویری مجاز هستند",
   "uploader.errors.max_size": "حداکثر حجم فایل {size} مگابایت است",


### PR DESCRIPTION
## Summary
- add categories API client and React Query hooks
- implement categories pages (list, add, edit, detail) and form/table components
- wire categories into routes, sidebar menu, and i18n strings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: A config object has a "plugins" key defined as an array of strings)


------
https://chatgpt.com/codex/tasks/task_e_68bd36348c388323a20883eca6f45ff6