### PR TITLE
Fix category parent selection and display

### DIFF
--- a/src/features/categories/components/layout/Form/CategoryForm.tsx
+++ b/src/features/categories/components/layout/Form/CategoryForm.tsx
@@ -149,7 +149,9 @@ export default function CategoryForm({
                                 <Select
                                     value={form.watch('parent_id') || ''}
                                     onValueChange={(val) =>
-                                        form.setValue('parent_id', val, { shouldDirty: true })
+                                        form.setValue('parent_id', val === 'none' ? '' : val, {
+                                            shouldDirty: true,
+                                        })
                                     }
                                 >
                                     <SelectTrigger id="category-parent" className="w-full">
@@ -158,7 +160,7 @@ export default function CategoryForm({
                                         />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="">
+                                        <SelectItem value="none">
                                             {t('categories.form.parent_none')}
                                         </SelectItem>
                                         {parentsQuery.data?.data.map((p) => (

--- a/src/features/categories/components/layout/Table/CategoriesTable.tsx
+++ b/src/features/categories/components/layout/Table/CategoriesTable.tsx
@@ -41,6 +41,12 @@ export default function CategoriesTable({ items, onDelete }: Props): JSX.Element
         [navigate],
     )
 
+    const getParentName = React.useCallback(
+        (parentId?: string | null) =>
+            items.find((x) => x.id === parentId)?.name ?? '-',
+        [items],
+    )
+
     return (
         <div className="relative overflow-hidden rounded-lg border">
             <Table>
@@ -75,7 +81,7 @@ export default function CategoriesTable({ items, onDelete }: Props): JSX.Element
                                 {c.name}
                             </TableCell>
                             <TableCell className="px-3 py-2.5">
-                                {c.parent_id ?? '-'}
+                                {getParentName(c.parent_id)}
                             </TableCell>
                             <TableCell className="px-3 py-2.5 text-right">
                                 <DropdownMenu>


### PR DESCRIPTION
## Summary
- fix category parent dropdown to avoid empty value errors
- show parent category names in category list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd461e20b883238ec012006b6fc996