### PR TITLE
Fix category tree node recursion and actions

### DIFF
--- a/src/features/categories/components/layout/Tree/CategoryNode.tsx
+++ b/src/features/categories/components/layout/Tree/CategoryNode.tsx
@@ -14,25 +14,34 @@ type Props = {
     node: Category;
     depth: number;
     expanded: boolean;
-    setExpanded: (v: boolean) => void;
-    onAddChild: () => void;
-    onEdit: () => void;
-    onDelete: () => void;
+    /**
+     * Sets the expanded state for a node by id. We pass this down so that
+     * nested nodes can update their own expanded state without wrapping
+     * callbacks for every level.
+     */
+    setExpanded: (id: string, v: boolean) => void;
+    /** Called with the current node id when user requests to add a child */
+    onAddChild: (parentId: string) => void;
+    /** Called with the current node id when user wants to edit */
+    onEdit: (id: string) => void;
+    /** Called with the current node id when user wants to delete */
+    onDelete: (id: string) => void;
     searchQuery?: string;
+    /** Map of expanded states for quick lookup */
     expandedState: Record<string, boolean>;
 };
 
 export default function CategoryNode({
-                                         node,
-                                         depth,
-                                         expanded,
-                                         setExpanded,
-                                         onAddChild,
-                                         onEdit,
-                                         onDelete,
-                                         searchQuery,
-                                         expandedState,
-                                     }: Props) {
+    node,
+    depth,
+    expanded,
+    setExpanded,
+    onAddChild,
+    onEdit,
+    onDelete,
+    searchQuery,
+    expandedState,
+}: Props) {
     const hasChildren = !!node.children?.length;
 
     const highlightName = React.useMemo(() => {
@@ -72,7 +81,7 @@ export default function CategoryNode({
                             variant="ghost"
                             size="icon"
                             className="h-6 w-6"
-                            onClick={() => setExpanded(!expanded)}
+                            onClick={() => setExpanded(node.id, !expanded)}
                             aria-label="toggle"
                         >
                             {expanded ? (
@@ -101,13 +110,15 @@ export default function CategoryNode({
                             </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={onAddChild}>
+                            <DropdownMenuItem onClick={() => onAddChild(node.id)}>
                                 افزودن زیر‌دسته
                             </DropdownMenuItem>
-                            <DropdownMenuItem onClick={onEdit}>ویرایش</DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => onEdit(node.id)}>
+                                ویرایش
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                                 className="text-destructive"
-                                onClick={onDelete}
+                                onClick={() => onDelete(node.id)}
                             >
                                 حذف
                             </DropdownMenuItem>
@@ -124,8 +135,8 @@ export default function CategoryNode({
                             key={child.id}
                             node={child}
                             depth={depth + 1}
-                            expanded={expandedState[child.id] ?? true}
-                            setExpanded={() => {}}
+                            expanded={expandedState[child.id] ?? false}
+                            setExpanded={setExpanded}
                             onAddChild={onAddChild}
                             onEdit={onEdit}
                             onDelete={onDelete}

--- a/src/features/categories/components/layout/Tree/CategoryTree.tsx
+++ b/src/features/categories/components/layout/Tree/CategoryTree.tsx
@@ -147,10 +147,10 @@ const CategoryTree = React.forwardRef<CategoryTreeHandle, Props>(function Catego
                             node={node}
                             depth={0}
                             expanded={expanded[node.id] ?? true}
-                            setExpanded={(v) => setExp(node.id, v)}
-                            onAddChild={() => onAddChild(node.id)}
-                            onEdit={() => onEdit(node.id)}
-                            onDelete={() => onDelete(node.id)}
+                            setExpanded={setExp}
+                            onAddChild={onAddChild}
+                            onEdit={onEdit}
+                            onDelete={onDelete}
                             searchQuery={searchQuery}
                             expandedState={expanded}
                         />


### PR DESCRIPTION
## Summary
- propagate IDs for nested category node actions
- enable expansion toggling for nested category tree nodes

## Testing
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings. Flat config requires "plugins" to be an object)*
- `npm run build` *(fails: TS2322, TS2307, TS7006)*

------
https://chatgpt.com/codex/tasks/task_e_68bd64da3d008323895924a5d44053cf