### PR TITLE
feat: add image uploader to category edit page

### DIFF
--- a/src/features/categories/components/CategoryForm.tsx
+++ b/src/features/categories/components/CategoryForm.tsx
@@ -7,16 +7,18 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useI18n } from '@/shared/hooks/useI18n'
+import CategoryImageField from '@/features/categories/components/CategoryImageField'
 import type { CreateCategoryRequest } from '@/features/categories/model/types'
 
 type CategoryFormValues = {
     name: string
     description?: string
-    image_url?: string
+    image_id?: string
 }
 
 type Props = Readonly<{
     defaultValues?: Partial<CategoryFormValues>
+    initialImageUrl?: string | null
     onSubmit: (data: CreateCategoryRequest) => void
     submitting?: boolean
     formId?: string
@@ -25,6 +27,7 @@ type Props = Readonly<{
 
 export default function CategoryForm({
     defaultValues,
+    initialImageUrl,
     onSubmit,
     submitting = false,
     formId = 'category-form',
@@ -47,12 +50,7 @@ export default function CategoryForm({
                         z.literal(''),
                     ])
                     .optional(),
-                image_url: z
-                    .union([
-                        z.string().max(2048, t('validation.max_length', { n: 2048 })),
-                        z.literal(''),
-                    ])
-                    .optional(),
+                image_id: z.union([z.string(), z.literal('')]).optional(),
             }),
         [t],
     )
@@ -62,7 +60,7 @@ export default function CategoryForm({
         defaultValues: {
             name: '',
             description: '',
-            image_url: '',
+            image_id: '',
             ...defaultValues,
         },
         mode: 'onBlur',
@@ -75,7 +73,7 @@ export default function CategoryForm({
             reset({
                 name: defaultValues.name ?? '',
                 description: defaultValues.description ?? '',
-                image_url: defaultValues.image_url ?? '',
+                image_id: defaultValues.image_id ?? '',
             })
         }
     }, [defaultValues, reset])
@@ -84,7 +82,7 @@ export default function CategoryForm({
         if (!apiErrors || apiErrors.length === 0) return
         apiErrors.forEach((err) => {
             const path = err.field?.split('.')?.pop() ?? err.field
-            if (path === 'name' || path === 'description' || path === 'image_url') {
+            if (path === 'name' || path === 'description' || path === 'image_id') {
                 setError(path as keyof CategoryFormValues, { type: 'server', message: err.message })
             }
         })
@@ -100,7 +98,7 @@ export default function CategoryForm({
                     const cleaned: CreateCategoryRequest = {
                         name: values.name.trim(),
                         description: values.description?.trim() || '',
-                        image_url: values.image_url?.trim() || '',
+                        image_id: values.image_id?.trim() || '',
                     }
                     onSubmit(cleaned)
                 })}
@@ -146,20 +144,7 @@ export default function CategoryForm({
                                 )}
                             </div>
 
-                            <div>
-                                <Label htmlFor="category-image">{t('categories.form.image')}</Label>
-                                <Input
-                                    id="category-image"
-                                    placeholder={t('categories.form.image_help')}
-                                    aria-invalid={Boolean(formState.errors.image_url)}
-                                    {...form.register('image_url')}
-                                />
-                                {formState.errors.image_url && (
-                                    <p className="mt-1 text-xs text-destructive">
-                                        {formState.errors.image_url.message}
-                                    </p>
-                                )}
-                            </div>
+                            <CategoryImageField initialImageUrl={initialImageUrl} />
                         </div>
                     </CardContent>
                 </Card>

--- a/src/features/categories/components/CategoryImageField.tsx
+++ b/src/features/categories/components/CategoryImageField.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { useFormContext } from 'react-hook-form'
+import CategoryImageUploader from '@/features/categories/components/CategoryImageUploader.tsx'
+import { useI18n } from '@/shared/hooks/useI18n.ts'
+import { CreateCategoryRequest } from '@/features/categories/model/types.ts'
+
+type Props = Readonly<{
+    initialImageUrl?: string | null
+}>
+
+export default function CategoryImageField({ initialImageUrl }: Props) {
+    const { t } = useI18n()
+    const { setValue } = useFormContext<CreateCategoryRequest>()
+    const [imagePreviewUrl, setImagePreviewUrl] = React.useState(initialImageUrl || '')
+
+    React.useEffect(() => {
+        setImagePreviewUrl(initialImageUrl || '')
+    }, [initialImageUrl])
+
+    return (
+        <div className="flex flex-col">
+            <CategoryImageUploader
+                value={imagePreviewUrl || ''}
+                onChange={(file) => {
+                    const id = file?.id || ''
+                    const url = file?.url || ''
+                    setImagePreviewUrl(url)
+                    setValue('image_id', id, { shouldDirty: true })
+                }}
+                label={t('categories.form.image')}
+                aspect="square"
+                className="h-56 w-full self-start"
+            />
+            <p className="mt-2 text-xs text-muted-foreground">
+                {t('categories.form.image_help')}
+            </p>
+        </div>
+    )
+}

--- a/src/features/categories/components/CategoryImageUploader.tsx
+++ b/src/features/categories/components/CategoryImageUploader.tsx
@@ -1,0 +1,215 @@
+import * as React from "react"
+import { JSX } from "react"
+import { Loader2, X } from "lucide-react"
+import axios, { AxiosError } from "axios"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { useI18n } from "@/shared/hooks/useI18n"
+import { uploadSingleImage } from "@/shared/api/files"
+
+type Props = Readonly<{
+    value?: string | null
+    onChange: (file: { id?: string | null; url?: string | null } | null) => void
+    label?: string
+    disabled?: boolean
+    maxSizeMB?: number
+    aspect?: "square" | "video"
+    className?: string
+}>
+
+export default function CategoryImageUploader({
+                                                value,
+                                                onChange,
+                                                label,
+                                                disabled = false,
+                                                maxSizeMB = 5,
+                                                aspect = "square",
+                                                className,
+                                            }: Props): JSX.Element {
+    const { t } = useI18n()
+    const [dragOver, setDragOver] = React.useState(false)
+    const [uploading, setUploading] = React.useState(false)
+    const [localPreview, setLocalPreview] = React.useState<string | null>(null)
+
+    const inputRef = React.useRef<HTMLInputElement>(null)
+    const abortRef = React.useRef<AbortController | null>(null)
+    const previewUrlRef = React.useRef<string | null>(null)
+
+    React.useEffect(() => {
+        return () => {
+            abortRef.current?.abort()
+            if (previewUrlRef.current) {
+                URL.revokeObjectURL(previewUrlRef.current)
+                previewUrlRef.current = null
+            }
+        }
+    }, [])
+
+    const validateFile = React.useCallback(
+        (file: File): boolean => {
+            if (!file.type.startsWith("image/")) {
+                toast.error(t("uploader.errors.type_image_only"))
+                return false
+            }
+            const maxBytes = maxSizeMB * 1024 * 1024
+            if (file.size > maxBytes) {
+                toast.error(t("uploader.errors.max_size", { size: maxSizeMB }))
+                return false
+            }
+            return true
+        },
+        [maxSizeMB, t]
+    )
+
+    const startPreviewAndUpload = React.useCallback(
+        async (file: File) => {
+            if (!validateFile(file) || disabled) return
+            if (localPreview) URL.revokeObjectURL(localPreview)
+
+            const objectUrl = URL.createObjectURL(file)
+            setLocalPreview(objectUrl)
+            previewUrlRef.current = objectUrl
+
+            abortRef.current?.abort()
+            abortRef.current = new AbortController()
+
+            try {
+                setUploading(true)
+                const { id, url } = await uploadSingleImage(file, abortRef.current.signal)
+                onChange({ id, url })
+                toast.success(t("uploader.success"))
+                URL.revokeObjectURL(objectUrl)
+                previewUrlRef.current = null
+                setLocalPreview(null)
+            } catch (err: unknown) {
+                if (
+                    (err instanceof DOMException && err.name === "AbortError") ||
+                    (axios.isCancel(err) || (err as AxiosError | undefined)?.code === "ERR_CANCELED")
+                )
+                    return
+                toast.error(t("uploader.errors.generic"))
+            } finally {
+                setUploading(false)
+            }
+        },
+        [disabled, localPreview, onChange, t, validateFile]
+    )
+
+    const handleFiles = React.useCallback(
+        (files: FileList | null) => {
+            if (!files || files.length === 0) return
+            void startPreviewAndUpload(files[0])
+        },
+        [startPreviewAndUpload]
+    )
+
+    const onDrop = React.useCallback(
+        (e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault()
+            setDragOver(false)
+            if (!disabled) void handleFiles(e.dataTransfer.files)
+        },
+        [disabled, handleFiles]
+    )
+
+    const openPicker = React.useCallback(() => {
+        if (!disabled) inputRef.current?.click()
+    }, [disabled])
+
+    const clearImage = React.useCallback(
+        (e?: React.MouseEvent<HTMLButtonElement>) => {
+            e?.stopPropagation()
+            onChange(null)
+            if (localPreview) {
+                URL.revokeObjectURL(localPreview)
+                previewUrlRef.current = null
+                setLocalPreview(null)
+            }
+        },
+        [localPreview, onChange]
+    )
+
+    const shownSrc = localPreview || value || undefined
+    const aspectClass = aspect === "square" ? "aspect-square" : "aspect-video"
+
+    const dropZoneClassName = [
+        "relative flex w-full items-center justify-center rounded-xl border border-dashed p-4",
+        aspectClass,
+        dragOver ? "bg-muted/50" : "bg-muted/20",
+        disabled ? "opacity-60 pointer-events-none" : "cursor-pointer",
+        className ?? "",
+    ].join(" ")
+
+    return (
+        <div className="grid gap-2">
+            <Label>{label ?? t("categories.form.image")}</Label>
+
+            <div
+                className={dropZoneClassName}
+                role="button"
+                tabIndex={0}
+                aria-label={t("uploader.aria.drop_or_click")}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        openPicker()
+                    }
+                }}
+                onClick={openPicker}
+                onDrop={onDrop}
+                onDragOver={(e) => {
+                    e.preventDefault()
+                    setDragOver(true)
+                }}
+                onDragLeave={() => setDragOver(false)}
+            >
+                {shownSrc ? (
+                    <div className="relative h-full w-full overflow-hidden rounded-lg">
+                        <img
+                            src={shownSrc}
+                            alt={t("categories.image_alt")}
+                            className="h-full w-full object-contain"
+                            loading="lazy"
+                            decoding="async"
+                        />
+
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="absolute right-2 top-2"
+                            onClick={clearImage}
+                        >
+                            <X className="h-4 w-4" />
+                            {t("uploader.actions.remove")}
+                        </Button>
+
+                        {uploading && (
+                            <div className="absolute inset-0 grid place-items-center rounded-lg bg-background/60 backdrop-blur">
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                    <span>{t("uploader.status.uploading")}</span>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <div className="text-center text-sm text-muted-foreground">
+                        {t("uploader.hint.drag_or_click")}
+                    </div>
+                )}
+            </div>
+
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                disabled={disabled}
+                onChange={(e) => void handleFiles(e.currentTarget.files)}
+            />
+        </div>
+    )
+}

--- a/src/features/categories/model/types.ts
+++ b/src/features/categories/model/types.ts
@@ -6,6 +6,7 @@ export interface CategoryData {
     description: string | null;
     parent_id: UUID | null;
     image_url: string | null;
+    image_id: string | null;
     order: number; // موقعیت بین خواهر-برادرها (از 0 شروع)
     created_at: string; // ISO8601
     updated_at: string; // ISO8601
@@ -16,13 +17,13 @@ export interface CreateCategoryRequest {
     parent_id?: UUID | null;
     order?: number; // اختیاری؛ اگر ندی انتهای لیست می‌رود
     description?: string | null;
-    image_url?: string | null;
+    image_id?: string | null;
 }
 
 export interface UpdateCategoryRequest {
     name?: string;
     description?: string | null;
-    image_url?: string | null;
+    image_id?: string | null;
     parent_id?: UUID | null; // برای جابه‌جایی والد
     order?: number;          // برای جابه‌جایی داخل همان والد یا جای جدید در والد جدید
 }

--- a/src/features/categories/pages/EditCategory/EditCategoryPage.tsx
+++ b/src/features/categories/pages/EditCategory/EditCategoryPage.tsx
@@ -15,7 +15,7 @@ import type { CreateCategoryRequest } from '@/features/categories/model/types'
 type CategoryFormValues = {
     name: string
     description?: string
-    image_url?: string
+    image_id?: string
 }
 
 const FORM_ID = 'category-form'
@@ -27,6 +27,7 @@ export default function EditCategoryPage() {
     const rtl = isRTLLocale(locale)
 
     const [initialData, setInitialData] = React.useState<CategoryFormValues | null>(null)
+    const [initialImageUrl, setInitialImageUrl] = React.useState<string | null>(null)
     const [loading, setLoading] = React.useState(true)
     const [saving, setSaving] = React.useState(false)
     const [apiErrors, setApiErrors] = React.useState<
@@ -44,8 +45,9 @@ export default function EditCategoryPage() {
                 setInitialData({
                     name: d.name,
                     description: d.description ?? '',
-                    image_url: d.image_url ?? '',
+                    image_id: d.image_id ?? '',
                 })
+                setInitialImageUrl(d.image_url ?? '')
             } catch {
                 toast.error(t('common.error'))
             } finally {
@@ -120,6 +122,7 @@ export default function EditCategoryPage() {
                     <CategoryForm
                         formId={FORM_ID}
                         defaultValues={initialData ?? undefined}
+                        initialImageUrl={initialImageUrl}
                         onSubmit={handleSubmit}
                         submitting={saving}
                         apiErrors={apiErrors}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -45,6 +45,7 @@
   "categories.title": "Categories",
   "categories.create": "Add Category",
   "categories.search_placeholder": "Search categories...",
+  "categories.image_alt": "Category image",
 
   "common.error": "Something went wrong",
   "common.back": "Back",

--- a/src/shared/i18n/locales/fa.json
+++ b/src/shared/i18n/locales/fa.json
@@ -45,6 +45,7 @@
   "categories.title": "دسته‌ها",
   "categories.create": "افزودن دسته",
   "categories.search_placeholder": "جستجوی دسته...",
+  "categories.image_alt": "تصویر دسته",
 
   "common.error": "مشکلی پیش آمد",
   "common.back": "بازگشت",


### PR DESCRIPTION
## Summary
- switch category form to use image uploader with `image_id`
- add CategoryImageField and CategoryImageUploader components
- include alt-text translation for category images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint plugin config requires object format)


------
https://chatgpt.com/codex/tasks/task_e_68c0104bdb408323834197119632a596