### PR TITLE
Fix category hierarchy after refresh

### DIFF
--- a/src/features/categories/components/NestedDraggableList.tsx
+++ b/src/features/categories/components/NestedDraggableList.tsx
@@ -60,8 +60,10 @@ export default function NestedDraggableList({
 
     // ---------- بارگذاری ----------
     const loadChildren = React.useCallback(async (parentId: UUID | null) => {
-        const res = await categoriesApiService.list({ parent_id: parentId ?? null, page: 1, limit: 100 })
-        const list = res.data.data // asc by server
+        // برخی API ها هنگام پاس دادن parent_id=null همه‌ی دسته‌ها را برمی‌گردانند.
+        // اینجا فقط آیتم‌هایی را نگه می‌داریم که والدشان همان parentId درخواست شده باشد.
+        const res = await categoriesApiService.list({ parent_id: parentId ?? undefined, page: 1, limit: 100 })
+        const list = res.data.data.filter((c) => c.parent_id === parentId) // asc by server
         return list.map(toNode)
     }, [])
 


### PR DESCRIPTION
## Summary
- filter category API results by parent to avoid flattening tree

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A config object has a "plugins" key defined as an array of strings. It looks something like this:...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2a53e1a8483239d044cc54dd3804a