### PR TITLE
feat: add product creation flow

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -14,6 +14,8 @@ import EditBrandPage from '@/features/brands/pages/EditBrand'
 import DetailBrandPage from '@/features/brands/pages/DetailBrand'
 import ListCategoriesPage from '@/features/categories/pages/ListCategories'
 import EditCategoryPage from '@/features/categories/pages/EditCategory'
+import ListProductsPage from '@/features/products/pages/ListProducts'
+import AddProductPage from '@/features/products/pages/AddProduct'
 
 export const router = createBrowserRouter([
     {
@@ -33,6 +35,9 @@ export const router = createBrowserRouter([
 
                     { path: ROUTES.CATEGORY.LIST, element: <ListCategoriesPage /> },
                     { path: ROUTES.CATEGORY.EDIT(), element: <EditCategoryPage /> },
+
+                    { path: ROUTES.PRODUCT.LIST, element: <ListProductsPage /> },
+                    { path: ROUTES.PRODUCT.NEW, element: <AddProductPage /> },
                 ],
             },
             { path: ROUTES.LOGIN, element: <LoginPage /> },

--- a/src/app/routes/routes.ts
+++ b/src/app/routes/routes.ts
@@ -17,4 +17,9 @@ export const ROUTES = {
         LIST: '/categories',
         EDIT: (id = ':id') => `/categories/${id}/edit`,
     },
+    // Product
+    PRODUCT: {
+        LIST: '/products',
+        NEW: '/products/new',
+    },
 } as const

--- a/src/features/products/components/layout/Form/ProductForm.tsx
+++ b/src/features/products/components/layout/Form/ProductForm.tsx
@@ -1,0 +1,170 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import * as React from 'react'
+import { JSX } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { CreateProductRequest } from '@/features/products/model/types'
+import ProductImageField from './ProductImageField'
+
+type Props = Readonly<{
+    defaultValues?: Partial<CreateProductRequest>
+    initialImageUrl?: string | null
+    onSubmit: (data: CreateProductRequest) => void
+    submitting?: boolean
+    formId?: string
+    apiErrors?: ReadonlyArray<{ field: string; message: string }>
+}>
+
+export default function ProductForm({
+    defaultValues,
+    initialImageUrl,
+    onSubmit,
+    submitting = false,
+    formId = 'product-form',
+    apiErrors,
+}: Props): JSX.Element {
+    const { t } = useI18n()
+
+    const schema = React.useMemo(
+        () =>
+            z.object({
+                sku: z.string().max(120).optional(),
+                name: z
+                    .string()
+                    .trim()
+                    .min(1, t('validation.required'))
+                    .max(120, t('validation.max_length', { n: 120 })),
+                price: z.preprocess((v) => Number(v), z.number().min(0, t('validation.required'))),
+                category_id: z.string().trim().min(1, t('validation.required')),
+                brand_id: z.string().optional(),
+                description: z.string().max(500).optional(),
+                primary_image_id: z.string().optional(),
+            }),
+        [t],
+    )
+
+    const form = useForm<CreateProductRequest>({
+        resolver: zodResolver(schema) as any,
+        defaultValues: {
+            sku: '',
+            name: '',
+            price: 0,
+            category_id: '',
+            brand_id: '',
+            description: '',
+            primary_image_id: '',
+            ...defaultValues,
+        },
+        mode: 'onBlur',
+    })
+
+    const { handleSubmit, reset, setError } = form
+
+    React.useEffect(() => {
+        if (defaultValues) {
+            reset({
+                sku: defaultValues.sku ?? '',
+                name: defaultValues.name ?? '',
+                price: defaultValues.price ?? 0,
+                category_id: defaultValues.category_id ?? '',
+                brand_id: defaultValues.brand_id ?? '',
+                description: defaultValues.description ?? '',
+                primary_image_id: defaultValues.primary_image_id ?? '',
+            })
+        }
+    }, [defaultValues, reset])
+
+    React.useEffect(() => {
+        if (!apiErrors || apiErrors.length === 0) return
+        apiErrors.forEach((err) => {
+            const path = err.field?.split('.')?.pop() ?? err.field
+            if (
+                path === 'sku' ||
+                path === 'name' ||
+                path === 'price' ||
+                path === 'category_id' ||
+                path === 'brand_id' ||
+                path === 'description' ||
+                path === 'primary_image_id'
+            ) {
+                setError(path as keyof CreateProductRequest, { type: 'server', message: err.message })
+            }
+        })
+    }, [apiErrors, setError])
+
+    return (
+        <FormProvider {...form}>
+            <form
+                id={formId}
+                noValidate
+                className="grid gap-6"
+                onSubmit={handleSubmit((values) => {
+                    const cleaned: CreateProductRequest = {
+                        sku: values.sku?.trim() || '',
+                        name: values.name.trim(),
+                        price: Number(values.price),
+                        category_id: values.category_id.trim(),
+                        brand_id: values.brand_id?.trim() || '',
+                        description: values.description?.trim() || '',
+                        primary_image_id: values.primary_image_id?.trim() || '',
+                    }
+                    onSubmit(cleaned)
+                })}
+            >
+                <Card className="overflow-hidden shadow-sm">
+                    <CardHeader className="bg-muted/50">
+                        <CardTitle className="text-lg font-semibold">
+                            {t('products.form.title')}
+                        </CardTitle>
+                    </CardHeader>
+
+                    <CardContent className="grid gap-6 p-6 md:grid-cols-2">
+                        <div className="flex flex-col gap-4">
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-sku">{t('products.form.sku')}</Label>
+                                <Input id="product-sku" placeholder={t('products.form.sku_ph')} {...form.register('sku')} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-name">{t('products.form.name')}*</Label>
+                                <Input id="product-name" placeholder={t('products.form.name_ph')} {...form.register('name')} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-price">{t('products.form.price')}*</Label>
+                                <Input
+                                    id="product-price"
+                                    type="number"
+                                    step="0.01"
+                                    placeholder={t('products.form.price_ph')}
+                                    {...form.register('price', { valueAsNumber: true })}
+                                />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-category">{t('products.form.category_id')}*</Label>
+                                <Input id="product-category" placeholder={t('products.form.category_id_ph')} {...form.register('category_id')} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-brand">{t('products.form.brand_id')}</Label>
+                                <Input id="product-brand" placeholder={t('products.form.brand_id_ph')} {...form.register('brand_id')} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="product-description">{t('products.form.description')}</Label>
+                                <textarea
+                                    id="product-description"
+                                    className="min-h-[80px] rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                    placeholder={t('products.form.description_ph')}
+                                    {...form.register('description')}
+                                />
+                            </div>
+                        </div>
+                        <ProductImageField initialImageUrl={initialImageUrl} />
+                    </CardContent>
+                </Card>
+            </form>
+        </FormProvider>
+    )
+}

--- a/src/features/products/components/layout/Form/ProductImageField.tsx
+++ b/src/features/products/components/layout/Form/ProductImageField.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { useFormContext } from 'react-hook-form'
+import ProductImageUploader from '@/features/products/components/layout/Uploader/ProductImageUploader'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { CreateProductRequest } from '@/features/products/model/types'
+
+type Props = Readonly<{ initialImageUrl?: string | null }>
+
+export default function ProductImageField({ initialImageUrl }: Props) {
+    const { t } = useI18n()
+    const { setValue } = useFormContext<CreateProductRequest>()
+    const [imagePreviewUrl, setImagePreviewUrl] = React.useState(initialImageUrl || '')
+
+    React.useEffect(() => {
+        setImagePreviewUrl(initialImageUrl || '')
+    }, [initialImageUrl])
+
+    return (
+        <div className="flex flex-col">
+            <ProductImageUploader
+                value={imagePreviewUrl || ''}
+                onChange={(file) => {
+                    const id = file?.id || ''
+                    const url = file?.url || ''
+                    setImagePreviewUrl(url)
+                    setValue('primary_image_id', id, { shouldDirty: true })
+                }}
+                label={t('products.form.image')}
+                aspect="square"
+                className="h-56 w-full self-start"
+            />
+            <p className="mt-2 text-xs text-muted-foreground">
+                {t('products.form.image_help')}
+            </p>
+        </div>
+    )
+}

--- a/src/features/products/components/layout/Uploader/ProductImageUploader.tsx
+++ b/src/features/products/components/layout/Uploader/ProductImageUploader.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react'
+import { JSX } from 'react'
+import { Loader2, X } from 'lucide-react'
+import axios, { AxiosError } from 'axios'
+import { toast } from 'sonner'
+
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { useI18n } from '@/shared/hooks/useI18n'
+import { uploadSingleImage } from '@/shared/api/files'
+
+type Props = Readonly<{
+    value?: string | null
+    onChange: (file: { id?: string | null; url?: string | null } | null) => void
+    label?: string
+    disabled?: boolean
+    maxSizeMB?: number
+    aspect?: 'square' | 'video'
+    className?: string
+}>
+
+export default function ProductImageUploader({
+    value,
+    onChange,
+    label,
+    disabled = false,
+    maxSizeMB = 5,
+    aspect = 'square',
+    className,
+}: Props): JSX.Element {
+    const { t } = useI18n()
+    const [dragOver, setDragOver] = React.useState(false)
+    const [uploading, setUploading] = React.useState(false)
+    const [localPreview, setLocalPreview] = React.useState<string | null>(null)
+
+    const inputRef = React.useRef<HTMLInputElement>(null)
+    const abortRef = React.useRef<AbortController | null>(null)
+    const previewUrlRef = React.useRef<string | null>(null)
+
+    React.useEffect(() => {
+        return () => {
+            abortRef.current?.abort()
+            if (previewUrlRef.current) {
+                URL.revokeObjectURL(previewUrlRef.current)
+                previewUrlRef.current = null
+            }
+        }
+    }, [])
+
+    const validateFile = React.useCallback(
+        (file: File): boolean => {
+            if (!file.type.startsWith('image/')) {
+                toast.error(t('uploader.errors.type_image_only'))
+                return false
+            }
+            const maxBytes = maxSizeMB * 1024 * 1024
+            if (file.size > maxBytes) {
+                toast.error(t('uploader.errors.max_size', { size: maxSizeMB }))
+                return false
+            }
+            return true
+        },
+        [maxSizeMB, t],
+    )
+
+    const startPreviewAndUpload = React.useCallback(
+        async (file: File) => {
+            if (!validateFile(file) || disabled) return
+            if (localPreview) URL.revokeObjectURL(localPreview)
+
+            const objectUrl = URL.createObjectURL(file)
+            setLocalPreview(objectUrl)
+            previewUrlRef.current = objectUrl
+
+            abortRef.current?.abort()
+            abortRef.current = new AbortController()
+
+            try {
+                setUploading(true)
+                const { id, url } = await uploadSingleImage(file, abortRef.current.signal)
+                onChange({ id, url })
+                toast.success(t('uploader.success'))
+                URL.revokeObjectURL(objectUrl)
+                previewUrlRef.current = null
+                setLocalPreview(null)
+            } catch (err: unknown) {
+                if (
+                    (err instanceof DOMException && err.name === 'AbortError') ||
+                    (axios.isCancel(err) || (err as AxiosError | undefined)?.code === 'ERR_CANCELED')
+                )
+                    return
+                toast.error(t('uploader.errors.generic'))
+            } finally {
+                setUploading(false)
+            }
+        },
+        [disabled, localPreview, onChange, t, validateFile],
+    )
+
+    const handleFiles = React.useCallback(
+        (files: FileList | null) => {
+            if (!files || files.length === 0) return
+            void startPreviewAndUpload(files[0])
+        },
+        [startPreviewAndUpload],
+    )
+
+    const onDrop = React.useCallback(
+        (e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault()
+            setDragOver(false)
+            if (!disabled) void handleFiles(e.dataTransfer.files)
+        },
+        [disabled, handleFiles],
+    )
+
+    const openPicker = React.useCallback(() => {
+        if (!disabled) inputRef.current?.click()
+    }, [disabled])
+
+    const clearImage = React.useCallback(
+        (e?: React.MouseEvent<HTMLButtonElement>) => {
+            e?.stopPropagation()
+            onChange(null)
+            if (localPreview) {
+                URL.revokeObjectURL(localPreview)
+                previewUrlRef.current = null
+                setLocalPreview(null)
+            }
+        },
+        [localPreview, onChange],
+    )
+
+    const shownSrc = localPreview || value || undefined
+    const aspectClass = aspect === 'square' ? 'aspect-square' : 'aspect-video'
+
+    const dropZoneClassName = [
+        'relative flex w-full items-center justify-center rounded-xl border border-dashed p-4',
+        aspectClass,
+        dragOver ? 'bg-muted/50' : 'bg-muted/20',
+        disabled ? 'opacity-60 pointer-events-none' : 'cursor-pointer',
+        className ?? '',
+    ].join(' ')
+
+    return (
+        <div className="grid gap-2">
+            <Label>{label ?? t('products.form.image')}</Label>
+
+            <div
+                className={dropZoneClassName}
+                role="button"
+                tabIndex={0}
+                aria-label={t('uploader.aria.drop_or_click')}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        openPicker()
+                    }
+                }}
+                onClick={openPicker}
+                onDrop={onDrop}
+                onDragOver={(e) => {
+                    e.preventDefault()
+                    setDragOver(true)
+                }}
+                onDragLeave={() => setDragOver(false)}
+            >
+                {shownSrc ? (
+                    <div className="relative h-full w-full overflow-hidden rounded-lg">
+                        <img
+                            src={shownSrc}
+                            alt={t('products.image_alt')}
+                            className="h-full w-full object-contain"
+                            loading="lazy"
+                            decoding="async"
+                        />
+
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="absolute right-2 top-2"
+                            onClick={clearImage}
+                        >
+                            <X className="h-4 w-4" />
+                            {t('uploader.actions.remove')}
+                        </Button>
+
+                        {uploading && (
+                            <div className="absolute inset-0 grid place-items-center rounded-lg bg-background/60 backdrop-blur">
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                    <span>{t('uploader.status.uploading')}</span>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                ) : (
+                    <div className="text-center text-sm text-muted-foreground">
+                        {t('uploader.hint.drag_or_click')}
+                    </div>
+                )}
+            </div>
+
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                disabled={disabled}
+                onChange={(e) => void handleFiles(e.currentTarget.files)}
+            />
+        </div>
+    )
+}

--- a/src/features/products/index.ts
+++ b/src/features/products/index.ts
@@ -1,0 +1,15 @@
+import { catalogClient } from '@/lib/axios'
+import { API_ROUTES } from '@/shared/constants/apiRoutes'
+import { createCrudApi } from '@/shared/api/crudFactory'
+import { createCrudHooks } from '@/shared/api/useCrudQueries'
+import type { ProductData, CreateProductRequest, UpdateProductRequest } from './model/types'
+
+export const productsApi = createCrudApi<ProductData, CreateProductRequest, UpdateProductRequest>(
+    catalogClient,
+    API_ROUTES.PRODUCTS.ROOT,
+)
+
+export const productsQueries = createCrudHooks<ProductData, CreateProductRequest, UpdateProductRequest>(
+    'product',
+    productsApi,
+)

--- a/src/features/products/model/types.ts
+++ b/src/features/products/model/types.ts
@@ -1,0 +1,77 @@
+export interface PackagingBarcode {
+    level: string
+    barcode: string
+    barcode_type: string
+}
+
+export interface Dimensions {
+    length: number
+    width: number
+    height: number
+    unit: string
+}
+
+export interface NutritionFacts {
+    calories?: number
+    fat?: number
+    protein?: number
+    carbohydrates?: number
+    [key: string]: number | undefined
+}
+
+export interface DietaryInfo {
+    halal?: boolean
+    kosher?: boolean
+    vegetarian?: boolean
+    vegan?: boolean
+    gluten_free?: boolean
+    [key: string]: boolean | undefined
+}
+
+export interface ProductData {
+    id: string
+    category_id: string
+    brand_id?: string | null
+    sku?: string
+    name: string
+    full_name?: string
+    description?: string
+    price: number
+    barcode?: string
+    barcode_type?: string
+    packaging_barcodes?: PackagingBarcode[]
+    unit_of_sale?: string
+    pack_size?: number
+    case_size?: number
+    pallet_size?: number
+    attributes?: Record<string, string>
+    weight?: number
+    weight_unit?: string
+    dimensions?: Dimensions
+    packaging?: string
+    storage?: string
+    shelf_life_days?: number
+    ingredients?: string[]
+    nutrition_facts?: NutritionFacts
+    dietary?: DietaryInfo
+    allergens?: string[]
+    is_active?: boolean
+    tags?: string[]
+    primary_image_id?: string | null
+    image_ids?: string[]
+    created_at?: string
+    updated_at?: string
+    deleted_at?: string | null
+}
+
+export interface CreateProductRequest {
+    sku?: string
+    name: string
+    price: number
+    category_id: string
+    brand_id?: string
+    description?: string
+    primary_image_id?: string
+}
+
+export type UpdateProductRequest = Partial<CreateProductRequest>

--- a/src/features/products/pages/AddProduct/AddProductPage.tsx
+++ b/src/features/products/pages/AddProduct/AddProductPage.tsx
@@ -1,0 +1,90 @@
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { toast } from 'sonner'
+import * as React from 'react'
+import { JSX } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { ROUTES } from '@/app/routes/routes'
+import { Button } from '@/components/ui/button'
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import ProductForm from '@/features/products/components/layout/Form/ProductForm'
+import type { CreateProductRequest } from '@/features/products/model/types'
+import { useI18n } from '@/shared/hooks/useI18n'
+import { isRTLLocale } from '@/shared/i18n/utils'
+import { productsQueries } from '@/features/products'
+
+const FORM_ID = 'product-form'
+
+export default function AddProductPage(): JSX.Element {
+    const navigate = useNavigate()
+    const { t, locale } = useI18n()
+    const rtl = isRTLLocale(locale)
+
+    const createMutation = productsQueries.useCreate()
+    const [apiErrors, setApiErrors] = React.useState<
+        ReadonlyArray<{ field: string; message: string }>
+    >([])
+
+    function handleSubmit(values: CreateProductRequest) {
+        setApiErrors([])
+
+        createMutation.mutate(values, {
+            onSuccess: () => {
+                toast.success(t('products.saved_success'))
+                navigate(ROUTES.PRODUCT.LIST)
+            },
+            onError: (err) => {
+                const resp = (err as { response?: { data?: unknown } }).response?.data as
+                    | { code?: number; errors?: Array<{ field: string; message: string }> }
+                    | undefined
+
+                if (resp?.code === 422 && Array.isArray(resp.errors)) {
+                    setApiErrors(resp.errors)
+                } else {
+                    toast.error(t('common.error'))
+                }
+            },
+        })
+    }
+
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="shadow-none"
+                            onClick={() => navigate(-1)}
+                            aria-label={t('common.back')}
+                            title={t('common.back')}
+                        >
+                            {rtl ? (
+                                <ArrowRight className="h-4 w-4" />
+                            ) : (
+                                <ArrowLeft className="h-4 w-4" />
+                            )}
+                        </Button>
+                        <h1 className="text-2xl font-bold tracking-tight">
+                            {t('products.add')}
+                        </h1>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <Button type="submit" form={FORM_ID} disabled={createMutation.isPending}>
+                            {createMutation.isPending ? t('common.saving') : t('common.save')}
+                        </Button>
+                    </div>
+                </div>
+
+                <ProductForm
+                    formId={FORM_ID}
+                    onSubmit={handleSubmit}
+                    submitting={createMutation.isPending}
+                    apiErrors={apiErrors}
+                />
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/products/pages/AddProduct/index.ts
+++ b/src/features/products/pages/AddProduct/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddProductPage'

--- a/src/features/products/pages/ListProducts/ListProductsPage.tsx
+++ b/src/features/products/pages/ListProducts/ListProductsPage.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+import { Link } from 'react-router-dom'
+
+import DashboardLayout from '@/components/layout/DashboardLayout'
+import { Button } from '@/components/ui/button'
+import { ROUTES } from '@/app/routes/routes'
+import { useI18n } from '@/shared/hooks/useI18n'
+
+export default function ListProductsPage() {
+    const { t } = useI18n()
+    return (
+        <DashboardLayout>
+            <div className="flex flex-1 flex-col gap-4 p-6 md:gap-6 md:p-8 lg:p-10">
+                <div className="flex items-center justify-between">
+                    <h1 className="text-2xl font-bold">{t('products.title')}</h1>
+                    <Button asChild>
+                        <Link to={ROUTES.PRODUCT.NEW}>{t('products.create')}</Link>
+                    </Button>
+                </div>
+                {/* Product list will be implemented here */}
+            </div>
+        </DashboardLayout>
+    )
+}

--- a/src/features/products/pages/ListProducts/index.ts
+++ b/src/features/products/pages/ListProducts/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ListProductsPage'

--- a/src/features/sidebar/app-sidebar.tsx
+++ b/src/features/sidebar/app-sidebar.tsx
@@ -51,6 +51,7 @@ const itemsSchema: MenuItem[] = [
         children: [
             { titleKey: "menu.basic.brand", url: ROUTES.BRAND.LIST },
             { titleKey: "menu.basic.category", url: ROUTES.CATEGORY.LIST },
+            { titleKey: "menu.basic.product", url: ROUTES.PRODUCT.LIST },
         ],
     },
 ]

--- a/src/shared/constants/apiRoutes.ts
+++ b/src/shared/constants/apiRoutes.ts
@@ -28,6 +28,9 @@ export const API_ROUTES = {
         REORDER: '/categories/reorder',
         REORDER_BY_ID: (id: string | number) => `/categories/${id}/reorder`,
     },
+    PRODUCTS: {
+        ROOT: '/products',
+    },
 } as const
 
 export type ApiRoute = typeof API_ROUTES

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -26,6 +26,7 @@
   "menu.basic": "Basic",
   "menu.basic.brand": "Brands",
   "menu.basic.category": "Categories",
+  "menu.basic.product": "Products",
 
   "user.guest": "Guest",
 
@@ -46,6 +47,13 @@
   "categories.create": "Add Category",
   "categories.search_placeholder": "Search categories...",
   "categories.image_alt": "Category image",
+
+  "products.saved_success": "Product saved successfully",
+  "products.add": "Add Product",
+  "products.title": "Products",
+  "products.create": "Add Product",
+  "products.search_placeholder": "Search products...",
+  "products.image_alt": "Product image",
 
   "common.error": "Something went wrong",
   "common.back": "Back",
@@ -94,6 +102,22 @@
   "categories.form.image": "Image",
   "categories.form.image_help": "Upload the category image (recommended square format)",
   "categories.help_drag_drop": "💡 Tip: Drag and drop items to reorder. Drop on a category to make it a subcategory.",
+
+  "products.form.title": "Product Information",
+  "products.form.name": "Name",
+  "products.form.name_ph": "Enter product name",
+  "products.form.sku": "SKU",
+  "products.form.sku_ph": "Enter SKU",
+  "products.form.price": "Price",
+  "products.form.price_ph": "Enter price",
+  "products.form.category_id": "Category",
+  "products.form.category_id_ph": "Enter category id",
+  "products.form.brand_id": "Brand",
+  "products.form.brand_id_ph": "Enter brand id",
+  "products.form.description": "Description",
+  "products.form.description_ph": "Enter description",
+  "products.form.image": "Image",
+  "products.form.image_help": "Upload the product image (recommended square format)",
 
   "validation.required": "This field is required",
   "validation.min_length": "Must be at least {n} characters",

--- a/src/shared/i18n/locales/fa.json
+++ b/src/shared/i18n/locales/fa.json
@@ -26,6 +26,7 @@
   "menu.basic": "پایه",
   "menu.basic.brand": "برندها",
   "menu.basic.category": "دسته‌ها",
+  "menu.basic.product": "محصولات",
 
   "user.guest": "مهمان",
 
@@ -46,6 +47,13 @@
   "categories.create": "افزودن دسته",
   "categories.search_placeholder": "جستجوی دسته...",
   "categories.image_alt": "تصویر دسته",
+
+  "products.saved_success": "محصول با موفقیت ذخیره شد",
+  "products.add": "افزودن محصول",
+  "products.title": "محصولات",
+  "products.create": "ایجاد محصول",
+  "products.search_placeholder": "جستجوی محصول...",
+  "products.image_alt": "تصویر محصول",
 
   "common.error": "مشکلی پیش آمد",
   "common.back": "بازگشت",
@@ -94,6 +102,22 @@
   "categories.form.image": "تصویر",
   "categories.form.image_help": "تصویر دسته را بارگذاری کنید (ترجیحاً مربع باشد)",
   "categories.help_drag_drop": "💡 راهنما: آیتم‌ها را بکشید و رها کنید تا جابجا شوند. برای تبدیل به زیردسته، روی دستهٔ مورد نظر رها کنید.",
+
+  "products.form.title": "اطلاعات محصول",
+  "products.form.name": "نام",
+  "products.form.name_ph": "نام محصول را وارد کنید",
+  "products.form.sku": "کد کالا",
+  "products.form.sku_ph": "کد کالا را وارد کنید",
+  "products.form.price": "قیمت",
+  "products.form.price_ph": "قیمت را وارد کنید",
+  "products.form.category_id": "دسته",
+  "products.form.category_id_ph": "شناسه دسته را وارد کنید",
+  "products.form.brand_id": "برند",
+  "products.form.brand_id_ph": "شناسه برند را وارد کنید",
+  "products.form.description": "توضیحات",
+  "products.form.description_ph": "توضیحات را وارد کنید",
+  "products.form.image": "تصویر",
+  "products.form.image_help": "تصویر محصول را بارگذاری کنید (ترجیحاً مربع باشد)",
 
   "validation.required": "این فیلد الزامی است",
   "validation.min_length": "حداقل باید {n} کاراکتر باشد",


### PR DESCRIPTION
## Summary
- add product API route and hooks
- build product form with image upload and validation
- expose product list/add pages and sidebar link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: plugins key should be object in eslint config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c2bd116e2c8323b7ed8a41933e9247