### PR TITLE
feat: expand product form with images and attributes

### DIFF
--- a/src/features/products/components/layout/Form/ProductAttributesField.tsx
+++ b/src/features/products/components/layout/Form/ProductAttributesField.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react'
+import { X, Plus } from 'lucide-react'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { CreateProductRequest } from '@/features/products/model/types'
+
+export default function ProductAttributesField() {
+    const { t } = useI18n()
+    const { control, register } = useFormContext<CreateProductRequest>()
+    const { fields, append, remove } = useFieldArray({ name: 'attributes', control })
+
+    return (
+        <div className="grid gap-2">
+            <Label>{t('products.form.attributes')}</Label>
+            <div className="grid gap-2">
+                {fields.map((field, index) => (
+                    <div key={field.id} className="flex items-center gap-2">
+                        <Input
+                            placeholder={t('products.form.key') as string}
+                            {...register(`attributes.${index}.key` as const)}
+                        />
+                        <Input
+                            placeholder={t('products.form.value') as string}
+                            {...register(`attributes.${index}.value` as const)}
+                        />
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="icon"
+                            onClick={() => remove(index)}
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    </div>
+                ))}
+            </div>
+            <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="w-fit"
+                onClick={() => append({ key: '', value: '' })}
+            >
+                <Plus className="mr-1 h-4 w-4" />
+                {t('products.form.add_attribute')}
+            </Button>
+        </div>
+    )
+}

--- a/src/features/products/components/layout/Form/ProductImagesField.tsx
+++ b/src/features/products/components/layout/Form/ProductImagesField.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react'
+import { X } from 'lucide-react'
+import { useFormContext } from 'react-hook-form'
+
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { useI18n } from '@/shared/hooks/useI18n'
+import type { CreateProductRequest } from '@/features/products/model/types'
+import ProductImageUploader from '@/features/products/components/layout/Uploader/ProductImageUploader'
+
+type ImageInfo = { id: string; url: string }
+
+type Props = Readonly<{
+    initialImages?: ReadonlyArray<ImageInfo>
+}>
+
+export default function ProductImagesField({ initialImages }: Props) {
+    const { t } = useI18n()
+    const { setValue } = useFormContext<CreateProductRequest>()
+    const [images, setImages] = React.useState<ImageInfo[]>(initialImages ? [...initialImages] : [])
+    const [uploadKey, setUploadKey] = React.useState(0)
+
+    React.useEffect(() => {
+        const imgs = initialImages ? [...initialImages] : []
+        setImages(imgs)
+        setValue('image_ids', imgs.map((img) => img.id), { shouldDirty: false })
+    }, [initialImages, setValue])
+
+    const addImage = React.useCallback(
+        (file: { id?: string | null; url?: string | null } | null) => {
+            if (!file?.id || !file.url) return
+            const newImages = [...images, { id: file.id, url: file.url }]
+            setImages(newImages)
+            setValue('image_ids', newImages.map((img) => img.id), { shouldDirty: true })
+            setUploadKey((k) => k + 1)
+        },
+        [images, setValue],
+    )
+
+    const removeImage = React.useCallback(
+        (index: number) => {
+            const newImages = images.filter((_, i) => i !== index)
+            setImages(newImages)
+            setValue('image_ids', newImages.map((img) => img.id), { shouldDirty: true })
+        },
+        [images, setValue],
+    )
+
+    return (
+        <div className="grid gap-2">
+            <Label>{t('products.form.images')}</Label>
+            <div className="flex flex-wrap gap-4">
+                {images.map((img, idx) => (
+                    <div key={img.id} className="relative h-24 w-24">
+                        <img
+                            src={img.url}
+                            alt={t('products.image_alt') as string}
+                            className="h-24 w-24 rounded-md border object-cover"
+                            loading="lazy"
+                            decoding="async"
+                        />
+                        <Button
+                            type="button"
+                            size="icon"
+                            variant="secondary"
+                            className="absolute -top-2 -right-2 h-6 w-6"
+                            onClick={() => removeImage(idx)}
+                        >
+                            <X className="h-3 w-3" />
+                        </Button>
+                    </div>
+                ))}
+                <ProductImageUploader
+                    key={uploadKey}
+                    value={null}
+                    onChange={addImage}
+                    label={t('products.form.add_image')}
+                    className="h-24 w-24"
+                />
+            </div>
+        </div>
+    )
+}

--- a/src/features/products/model/types.ts
+++ b/src/features/products/model/types.ts
@@ -142,6 +142,8 @@ export interface CreateProductRequest {
     shelf_life_days?: number
     is_active?: boolean
     primary_image_id?: string
+    image_ids?: string[]
+    attributes?: Attribute[]
 }
 
 export type UpdateProductRequest = Partial<CreateProductRequest>

--- a/src/features/products/pages/DetailProduct/DetailProductPage.tsx
+++ b/src/features/products/pages/DetailProduct/DetailProductPage.tsx
@@ -20,6 +20,16 @@ export default function DetailProductPage() {
 
     const { data, isLoading, isError, error, refetch } = productsQueries.useDetail(id)
     const product = data?.data
+    const attributes = React.useMemo(
+        () =>
+            Array.isArray(product?.attributes)
+                ? product?.attributes
+                : product?.attributes
+                  ? Object.entries(product.attributes).map(([key, value]) => ({ key, value }))
+                  : [],
+        [product],
+    )
+    const images = React.useMemo(() => product?.images ?? [], [product])
 
     const goEdit = React.useCallback(() => {
         if (!product?.id) return
@@ -117,17 +127,61 @@ export default function DetailProductPage() {
                                         {product.description || '—'}
                                     </p>
                                 </div>
+                                {attributes.length > 0 && (
+                                    <>
+                                        <Separator />
+                                        <div className="grid gap-2">
+                                            <span className="text-xs text-muted-foreground">
+                                                {t('products.form.attributes')}
+                                            </span>
+                                            <ul className="text-sm leading-6">
+                                                {attributes.map((a) => (
+                                                    <li key={a.key} className="break-words">
+                                                        {a.key}: {a.value}
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    </>
+                                )}
                             </div>
 
-                            <div className="flex items-start justify-center">
-                                {product.images && product.images[0]?.url ? (
-                                    <img
-                                        src={toAbsoluteUrl(product.images[0].url)}
-                                        alt={t('products.image_alt') as string}
-                                        className="h-72 w-full max-w-[360px] rounded-lg object-contain border bg-background"
-                                        loading="lazy"
-                                        decoding="async"
-                                    />
+                            <div className="flex flex-col items-start justify-center gap-4">
+                                {images.length > 0 ? (
+                                    <>
+                                        <img
+                                            src={toAbsoluteUrl(
+                                                (
+                                                    images.find((i) => i.id === product.primary_image_id) ||
+                                                    images[0]
+                                                ).url || '',
+                                            )}
+                                            alt={t('products.image_alt') as string}
+                                            className="h-72 w-full max-w-[360px] rounded-lg object-contain border bg-background"
+                                            loading="lazy"
+                                            decoding="async"
+                                        />
+                                        {images.length > 1 && (
+                                            <div className="flex flex-wrap gap-2">
+                                                {images
+                                                    .filter(
+                                                        (img) =>
+                                                            img.id !==
+                                                            (product.primary_image_id ?? images[0].id),
+                                                    )
+                                                    .map((img) => (
+                                                        <img
+                                                            key={img.id}
+                                                            src={toAbsoluteUrl(img.url || '')}
+                                                            alt={t('products.image_alt') as string}
+                                                            className="h-20 w-20 rounded-md object-cover border bg-background"
+                                                            loading="lazy"
+                                                            decoding="async"
+                                                        />
+                                                    ))}
+                                            </div>
+                                        )}
+                                    </>
                                 ) : (
                                     <div className="h-72 w-full max-w-[360px] rounded-lg border bg-muted/30" />
                                 )}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -136,6 +136,12 @@
   "products.form.description_ph": "Enter description",
   "products.form.image": "Image",
   "products.form.image_help": "Upload the product image (recommended square format)",
+  "products.form.images": "Additional Images",
+  "products.form.add_image": "Add Image",
+  "products.form.attributes": "Attributes",
+  "products.form.add_attribute": "Add Attribute",
+  "products.form.key": "Key",
+  "products.form.value": "Value",
 
   "products.table.name": "Name",
   "products.table.sku": "SKU",

--- a/src/shared/i18n/locales/fa.json
+++ b/src/shared/i18n/locales/fa.json
@@ -136,6 +136,12 @@
   "products.form.description_ph": "توضیحات را وارد کنید",
   "products.form.image": "تصویر",
   "products.form.image_help": "تصویر محصول را بارگذاری کنید (ترجیحاً مربع باشد)",
+  "products.form.images": "تصاویر اضافی",
+  "products.form.add_image": "افزودن تصویر",
+  "products.form.attributes": "ویژگی‌ها",
+  "products.form.add_attribute": "افزودن ویژگی",
+  "products.form.key": "کلید",
+  "products.form.value": "مقدار",
 
   "products.table.name": "نام",
   "products.table.sku": "کد کالا",


### PR DESCRIPTION
## Summary
- allow uploading multiple product images and editing attributes
- show image gallery and attributes on product detail page
- handle existing images when editing products

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: config requires flat plugin format)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c5241b31e0832382e285d62a8af3b4