### PR TITLE
fix: show images when editing product

### DIFF
--- a/src/features/products/components/layout/Form/ProductImageField.tsx
+++ b/src/features/products/components/layout/Form/ProductImageField.tsx
@@ -3,25 +3,26 @@ import { useFormContext } from 'react-hook-form'
 import ProductImageUploader from '@/features/products/components/layout/Uploader/ProductImageUploader'
 import { useI18n } from '@/shared/hooks/useI18n'
 import type { CreateProductRequest } from '@/features/products/model/types'
+import { toAbsoluteUrl } from '@/shared/api/files'
 
 type Props = Readonly<{ initialImageUrl?: string | null }>
 
 export default function ProductImageField({ initialImageUrl }: Props) {
     const { t } = useI18n()
     const { setValue } = useFormContext<CreateProductRequest>()
-    const [imagePreviewUrl, setImagePreviewUrl] = React.useState(initialImageUrl || '')
+    const [imagePreviewUrl, setImagePreviewUrl] = React.useState<string>('')
 
     React.useEffect(() => {
-        setImagePreviewUrl(initialImageUrl || '')
+        setImagePreviewUrl(initialImageUrl ? toAbsoluteUrl(initialImageUrl) : '')
     }, [initialImageUrl])
 
     return (
         <div className="flex flex-col">
             <ProductImageUploader
-                value={imagePreviewUrl || ''}
+                value={imagePreviewUrl ? imagePreviewUrl : null}
                 onChange={(file) => {
                     const id = file?.id || ''
-                    const url = file?.url || ''
+                    const url = file?.url ? toAbsoluteUrl(file.url) : ''
                     setImagePreviewUrl(url)
                     setValue('primary_image_id', id, { shouldDirty: true })
                 }}

--- a/src/features/products/components/layout/Form/ProductImagesField.tsx
+++ b/src/features/products/components/layout/Form/ProductImagesField.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label'
 import { useI18n } from '@/shared/hooks/useI18n'
 import type { CreateProductRequest } from '@/features/products/model/types'
 import ProductImageUploader from '@/features/products/components/layout/Uploader/ProductImageUploader'
+import { toAbsoluteUrl } from '@/shared/api/files'
 
 type ImageInfo = { id: string; url: string }
 
@@ -17,11 +18,17 @@ type Props = Readonly<{
 export default function ProductImagesField({ initialImages }: Props) {
     const { t } = useI18n()
     const { setValue } = useFormContext<CreateProductRequest>()
-    const [images, setImages] = React.useState<ImageInfo[]>(initialImages ? [...initialImages] : [])
+    const [images, setImages] = React.useState<ImageInfo[]>(
+        initialImages
+            ? initialImages.map((img) => ({ id: img.id, url: toAbsoluteUrl(img.url) }))
+            : [],
+    )
     const [uploadKey, setUploadKey] = React.useState(0)
 
     React.useEffect(() => {
-        const imgs = initialImages ? [...initialImages] : []
+        const imgs = initialImages
+            ? initialImages.map((img) => ({ id: img.id, url: toAbsoluteUrl(img.url) }))
+            : []
         setImages(imgs)
         setValue('image_ids', imgs.map((img) => img.id), { shouldDirty: false })
     }, [initialImages, setValue])
@@ -29,7 +36,7 @@ export default function ProductImagesField({ initialImages }: Props) {
     const addImage = React.useCallback(
         (file: { id?: string | null; url?: string | null } | null) => {
             if (!file?.id || !file.url) return
-            const newImages = [...images, { id: file.id, url: file.url }]
+            const newImages = [...images, { id: file.id, url: toAbsoluteUrl(file.url) }]
             setImages(newImages)
             setValue('image_ids', newImages.map((img) => img.id), { shouldDirty: true })
             setUploadKey((k) => k + 1)


### PR DESCRIPTION
## Summary
- ensure initial product images are resolved to full URLs
- use absolute URLs and null handling in product image fields

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: config object has a "plugins" key defined as an array of strings)


------
https://chatgpt.com/codex/tasks/task_e_68c531e604f88323a9c89c36649081b8