### PR TITLE
Update admin login flow for new API contract

### DIFF
--- a/src/features/auth/services/auth.api.ts
+++ b/src/features/auth/services/auth.api.ts
@@ -3,43 +3,152 @@ import { authClient } from '@/lib/axios'
 import { API_ROUTES } from '@/shared/constants/apiRoutes'
 import { handleAsyncError } from '@/shared/lib/errors'
 import { defaultLogger } from '@/shared/lib/logger'
-import { AuthUser } from '../types'
+import { AuthLoginResult, AuthUser } from '../types'
 
 function getLogger(action: string, context: Record<string, unknown> = {}) {
     return defaultLogger.withContext({ component: 'auth.api', action, ...context })
 }
 
-export async function apiLogin(username: string, password: string) {
+const DEVICE_ID_STORAGE_KEY = 'auth.deviceId'
+
+type NavigatorWithUAData = Navigator & {
+    userAgentData?: {
+        brands?: Array<{ brand: string; version?: string }>
+        platform?: string
+        platformVersion?: string
+    }
+}
+
+type RawLoginPayload = {
+    access_token?: unknown
+    refresh_token?: unknown
+    id_token?: unknown
+    expires_in?: unknown
+    token_type?: unknown
+    audience?: unknown
+    profile?: unknown
+}
+
+function normalizeString(value: unknown, fallback = ''): string {
+    if (typeof value === 'string') return value
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+    return fallback
+}
+
+function ensureDeviceId(): string {
+    if (typeof window === 'undefined') return 'web-unknown-device'
+
+    try {
+        const existing = localStorage.getItem(DEVICE_ID_STORAGE_KEY)
+        if (existing) {
+            return existing
+        }
+
+        const newId =
+            typeof crypto !== 'undefined' && 'randomUUID' in crypto
+                ? crypto.randomUUID()
+                : `device-${Math.random().toString(36).slice(2)}-${Date.now()}`
+
+        localStorage.setItem(DEVICE_ID_STORAGE_KEY, newId)
+        return newId
+    } catch {
+        return 'web-unknown-device'
+    }
+}
+
+function detectBrowserName(userAgent: string): string {
+    if (!userAgent) return 'unknown'
+    if (/Edg\//i.test(userAgent)) return 'Edge'
+    if (/OPR\//i.test(userAgent) || /Opera/i.test(userAgent)) return 'Opera'
+    if (/Chrome\//i.test(userAgent)) return 'Chrome'
+    if (/Safari/i.test(userAgent) && /Version\//i.test(userAgent)) return 'Safari'
+    if (/Firefox\//i.test(userAgent)) return 'Firefox'
+    return 'unknown'
+}
+
+function getLoginContext() {
+    const nav =
+        typeof navigator === 'undefined' ? undefined : (navigator as NavigatorWithUAData)
+    const uaData = nav?.userAgentData
+    const userAgent = normalizeString(nav?.userAgent, '')
+
+    const platform = normalizeString(uaData?.platform || nav?.platform, 'web')
+    const platformVersion = normalizeString(
+        uaData?.platformVersion || nav?.appVersion,
+        userAgent || 'unknown',
+    )
+
+    const browserName = normalizeString(
+        uaData?.brands?.[0]?.brand,
+        detectBrowserName(userAgent),
+    )
+
+    return {
+        device_id: ensureDeviceId(),
+        platform,
+        platform_version: platformVersion || 'unknown',
+        browser_name: browserName || 'unknown',
+        browser_system_name: normalizeString(nav?.platform, platform) || 'unknown',
+        browser_system_version:
+            normalizeString(nav?.appVersion, userAgent || 'unknown') || 'unknown',
+        app_version: import.meta.env.VITE_APP_VERSION || '1.0.0',
+    }
+}
+
+export async function apiLogin(username: string, password: string): Promise<AuthLoginResult> {
     const logger = getLogger('login', { username })
 
     logger.info('Attempting login')
 
-    const context = {
-        platform: 'web',
-        browser_name: navigator.userAgent,
-        browser_system_name: navigator.platform,
-        browser_system_version: navigator.userAgent,
-        app_version: import.meta.env.VITE_APP_VERSION || '1.0.0',
-    }
-
     return handleAsyncError(
         authClient
-            .post(API_ROUTES.AUTH.LOGIN, { username, password, context })
+            .post(API_ROUTES.AUTH.LOGIN, {
+                username,
+                password,
+                context: getLoginContext(),
+            })
             .then(({ data: response }) => {
                 logger.info('Login successful')
-                const { access_token, refresh_token, profile } = response.data
-                const user: AuthUser = {
-                    id: profile.id,
-                    username,
-                    email: profile.email,
-                    firstName: profile.first_name,
-                    lastName: profile.last_name,
-                    phone: profile.phone,
-                    avatar: profile.avatar,
+                const payload = (response?.data ?? response ?? {}) as RawLoginPayload
+                const {
+                    access_token,
+                    refresh_token,
+                    id_token = null,
+                    expires_in = 0,
+                    token_type = 'Bearer',
+                    audience = [],
+                    profile = {},
+                } = payload
+
+                const normalizedProfile = (profile ?? {}) as Record<string, unknown>
+
+                const accessToken = normalizeString(access_token, '')
+                const refreshToken = normalizeString(refresh_token, '')
+                if (!accessToken || !refreshToken) {
+                    throw new Error('Invalid login response: missing tokens')
                 }
+
+                const user: AuthUser = {
+                    id: normalizeString(normalizedProfile.id, username),
+                    username: normalizeString(normalizedProfile.username, username),
+                    email: normalizeString(normalizedProfile.email, ''),
+                    firstName: normalizeString(normalizedProfile.first_name, ''),
+                    lastName: normalizeString(normalizedProfile.last_name, ''),
+                    phone: normalizeString(normalizedProfile.phone, '') || undefined,
+                    avatar: normalizeString(normalizedProfile.avatar, '') || undefined,
+                }
+
                 return {
-                    accessToken: access_token,
-                    refreshToken: refresh_token,
+                    accessToken,
+                    refreshToken,
+                    idToken: normalizeString(id_token, '') || null,
+                    expiresIn: Number(expires_in) || 0,
+                    tokenType: normalizeString(token_type, 'Bearer'),
+                    audience: Array.isArray(audience)
+                        ? audience
+                              .map((entry) => normalizeString(entry, ''))
+                              .filter((entry) => entry.length > 0)
+                        : [],
                     user,
                 }
             }),

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -9,6 +9,16 @@ export type AuthUser = {
     avatar?: string
 }
 
+export type AuthLoginResult = {
+    accessToken: string
+    refreshToken: string
+    idToken: string | null
+    expiresIn: number
+    tokenType: string
+    audience: string[]
+    user: AuthUser
+}
+
 export type AuthCtx = {
     user: AuthUser | null
     accessToken: string | null

--- a/src/shared/constants/apiRoutes.ts
+++ b/src/shared/constants/apiRoutes.ts
@@ -2,7 +2,7 @@ import { API_CONFIG } from '@/shared/config/api.config'
 
 export const API_ROUTES = {
     AUTH: {
-        LOGIN: '/api/admins/login',
+        LOGIN: '/api/v1/admin/auth/login',
         LOGOUT: '/api/users/logout',
         ME: '/auth/me',
         REFRESH: '/auth/refresh',


### PR DESCRIPTION
## Summary
- update the admin login route to `/api/v1/admin/auth/login`
- send the richer login context (device, platform, browser, app version) expected by the new auth service
- parse the new login response payload, returning the additional token metadata and normalizing the profile fields

## Testing
- npm run lint *(fails: eslint flat config requires plugin objects; repo config still references legacy plugin arrays)*

------
https://chatgpt.com/codex/tasks/task_e_68d100c343508323b07629262965e6df