### PR TITLE
Fix session details normalization and update logout API

### DIFF
--- a/src/features/auth/services/auth.api.ts
+++ b/src/features/auth/services/auth.api.ts
@@ -171,7 +171,7 @@ export async function apiLogout() {
     logger.info('Attempting logout')
 
     return handleAsyncError(
-        authClient.delete(API_ROUTES.AUTH.LOGOUT).then(({ data }) => {
+        authClient.delete(API_ROUTES.SESSIONS.CURRENT).then(({ data }) => {
             logger.info('Logout successful')
             return data
         }),

--- a/src/features/sessions/api.ts
+++ b/src/features/sessions/api.ts
@@ -1,11 +1,101 @@
 import { authClient } from '@/lib/axios'
 import { API_ROUTES } from '@/shared/constants/apiRoutes'
 
-import type { SessionRecord, SessionsResponse } from './model/types'
+import type { RawSessionRecord, SessionRecord, SessionsResponse } from './model/types'
 
 type RequestOptions = {
     signal?: AbortSignal
     params?: Record<string, unknown>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function toOptionalString(value: unknown): string | null {
+    if (value === undefined || value === null) return null
+    if (typeof value === 'string') return value
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value)
+    }
+    return null
+}
+
+function toOptionalBoolean(value: unknown): boolean | undefined {
+    if (value === undefined || value === null) return undefined
+    if (typeof value === 'boolean') return value
+    if (typeof value === 'number') {
+        if (Number.isNaN(value)) return undefined
+        return value !== 0
+    }
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase()
+        if (!normalized) return undefined
+        if (['true', '1', 'yes', 'y'].includes(normalized)) return true
+        if (['false', '0', 'no', 'n'].includes(normalized)) return false
+    }
+    return undefined
+}
+
+function pickValue(source: Record<string, unknown>, keys: string[]): unknown {
+    for (const key of keys) {
+        if (key in source) {
+            const value = source[key]
+            if (value !== undefined) {
+                return value
+            }
+        }
+    }
+    return undefined
+}
+
+function normalizeSessionRecord(raw: RawSessionRecord | SessionRecord | unknown): SessionRecord | null {
+    if (!isRecord(raw)) {
+        return null
+    }
+
+    const pickString = (...keys: string[]) => toOptionalString(pickValue(raw, keys))
+    const pickBoolean = (...keys: string[]) => toOptionalBoolean(pickValue(raw, keys))
+
+    const sessionId = pickString('session_id', 'sessionId', 'id')
+    if (!sessionId) {
+        return null
+    }
+
+    return {
+        session_id: sessionId,
+        app_context: pickString('app_context', 'appContext'),
+        locale: pickString('locale'),
+        ip_address: pickString('ip_address', 'ipAddress'),
+        user_agent: pickString('user_agent', 'userAgent'),
+        device_id: pickString('device_id', 'deviceId'),
+        platform: pickString('platform'),
+        platform_version: pickString('platform_version', 'platformVersion'),
+        browser_name: pickString('browser_name', 'browserName'),
+        browser_system_name: pickString('browser_system_name', 'browserSystemName'),
+        browser_system_version: pickString('browser_system_version', 'browserSystemVersion'),
+        app_version: pickString('app_version', 'appVersion'),
+        status: pickString('status'),
+        issued_at: pickString('issued_at', 'issuedAt'),
+        expires_at: pickString('expires_at', 'expiresAt'),
+        revoked_at: pickString('revoked_at', 'revokedAt'),
+        is_current: pickBoolean('is_current', 'isCurrent'),
+    }
+}
+
+function normalizeSessions(payload: SessionsResponse['data']): SessionRecord[] {
+    if (!payload) {
+        return []
+    }
+
+    if (Array.isArray(payload)) {
+        return payload
+            .map((item) => normalizeSessionRecord(item))
+            .filter((item): item is SessionRecord => Boolean(item))
+    }
+
+    const record = normalizeSessionRecord(payload)
+    return record ? [record] : []
 }
 
 export async function fetchCurrentSession({
@@ -17,7 +107,8 @@ export async function fetchCurrentSession({
         params: params ?? { offset: 0, limit: 1 },
     })
 
-    return data?.data?.[0] ?? null
+    const sessions = normalizeSessions(data?.data)
+    return sessions[0] ?? null
 }
 
 export async function fetchOtherSessions({ signal }: RequestOptions = {}): Promise<SessionRecord[]> {
@@ -25,7 +116,7 @@ export async function fetchOtherSessions({ signal }: RequestOptions = {}): Promi
         signal,
     })
 
-    return data?.data ?? []
+    return normalizeSessions(data?.data)
 }
 
 export async function revokeOtherSessions(): Promise<void> {

--- a/src/features/sessions/model/types.ts
+++ b/src/features/sessions/model/types.ts
@@ -18,7 +18,15 @@ export type SessionRecord = {
     is_current?: boolean
 }
 
+export type RawSessionRecord = Record<string, unknown> & {
+    session_id?: unknown
+    sessionId?: unknown
+    id?: unknown
+    is_current?: unknown
+    isCurrent?: unknown
+}
+
 export type SessionsResponse = {
-    data?: SessionRecord[] | null
+    data?: RawSessionRecord | RawSessionRecord[] | null
     meta?: unknown
 }

--- a/src/features/sessions/pages/SessionsPage.tsx
+++ b/src/features/sessions/pages/SessionsPage.tsx
@@ -139,7 +139,7 @@ export default function SessionsPage() {
                 {
                     key: 'session_id',
                     label: t('sessions.fields.session_id') as string,
-                    value: session.session_id,
+                    value: session.session_id || fallback,
                 },
                 {
                     key: 'status',


### PR DESCRIPTION
## Summary
- normalize session API responses to support both snake_case and camelCase payloads
- ensure session details render even when optional fields are missing from the payload
- switch the logout flow to use the new current session revocation endpoint

## Testing
- npm run lint *(fails: ESLint flat config requires plugin objects instead of string arrays in the existing config)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e9fad4648323a7b1f2135a012a68