### PR TITLE
Align brand social links with updated API schema

### DIFF
--- a/src/features/brands/components/layout/Form/BrandSocialLinksFields.tsx
+++ b/src/features/brands/components/layout/Form/BrandSocialLinksFields.tsx
@@ -67,18 +67,18 @@ export default function BrandSocialLinksFields() {
             </div>
 
             <div>
-                <Label htmlFor="brand-social-twitter">
-                    {t('brands.form.social.twitter')}
+                <Label htmlFor="brand-social-x">
+                    {t('brands.form.social.x')}
                 </Label>
                 <Input
-                    id="brand-social-twitter"
-                    placeholder={t('brands.form.social.twitter_ph')}
+                    id="brand-social-x"
+                    placeholder={t('brands.form.social.x_ph')}
                     autoComplete="url"
-                    {...register('social_links.twitter')}
+                    {...register('social_links.x')}
                 />
-                {socialErrors.twitter && (
+                {socialErrors.x && (
                     <p className="mt-1 text-xs text-destructive">
-                        {socialErrors.twitter.message}
+                        {socialErrors.x.message}
                     </p>
                 )}
             </div>

--- a/src/features/brands/model/types.ts
+++ b/src/features/brands/model/types.ts
@@ -1,9 +1,11 @@
 import type { ApiResponse } from '@/shared/api/types'
+import type { SocialLinkKey } from '@/shared/constants/socialLinks'
 import type { LocalizedValue } from '@/shared/utils/localized'
 
 export type LocalizedField = LocalizedValue
 
-export type SocialLinks = LocalizedValue
+export type SocialLinks = Partial<Record<SocialLinkKey, string | null | undefined>>
+export type SocialLinksPayload = Partial<Record<SocialLinkKey, string>>
 
 export interface BrandData {
     id: string
@@ -16,7 +18,7 @@ export interface BrandData {
     is_active: boolean
     social_links?: SocialLinks | null
     issued_at: string
-    updated_at: string
+    updated_at: string | null
 }
 
 export interface CreateBrandRequest {
@@ -26,7 +28,7 @@ export interface CreateBrandRequest {
     logo_id?: string
     slug: string
     is_active: boolean
-    social_links?: Record<string, string>
+    social_links?: SocialLinksPayload
 }
 
 export type UpdateBrandRequest = Partial<CreateBrandRequest>
@@ -41,7 +43,7 @@ export interface BrandFormValues {
     website_url: string
     is_active: boolean
     logo_id?: string
-    social_links: Record<string, string>
+    social_links: SocialLinksPayload
 }
 
 export interface UploadFilesResponse {

--- a/src/features/brands/pages/EditBrand/Container.tsx
+++ b/src/features/brands/pages/EditBrand/Container.tsx
@@ -9,7 +9,7 @@ import { ROUTES } from "@/app/routes/routes"
 import { useI18n } from "@/shared/hooks/useI18n"
 import { defaultLogger } from "@/shared/lib/logger"
 import { toAbsoluteUrl } from "@/shared/api/files"
-import { ensureLocalizedDefaults, cleanLocalizedField, getLocalizedValue } from "@/shared/utils/localized"
+import { ensureLocalizedDefaults, cleanLocalizedField, cleanSocialLinks, getLocalizedValue } from "@/shared/utils/localized"
 
 const SUPPORTED_LOCALES = ['en', 'fa'] as const
 
@@ -23,13 +23,12 @@ function brandToFormDefaults(b?: BrandData): Partial<BrandFormValues> {
         ...ensureLocalizedDefaults(b.description ?? undefined, SUPPORTED_LOCALES),
         ...(cleanLocalizedField(b.description ?? undefined) ?? {}),
     }
-    const social = Object.entries(b.social_links ?? {}).reduce<Record<string, string>>(
-        (acc, [key, value]) => {
-            acc[key] = typeof value === 'string' ? value : ''
-            return acc
-        },
-        {},
-    )
+    const social = Object.entries(cleanSocialLinks(b.social_links ?? undefined) ?? {}).reduce<
+        Record<string, string>
+    >((acc, [key, value]) => {
+        acc[key] = value
+        return acc
+    }, {})
 
     return {
         name,

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -15,11 +15,14 @@ export interface Pagination {
 export interface ApiMeta {
     message: string
     status: string
-    code: string
+    code: number | string
     pagination?: Pagination
     method?: string
     path?: string
     timestamp?: string
+    trace_id?: string
+    request_id?: string
+    host?: string
 }
 
 /** Generic envelope for all API responses */

--- a/src/shared/constants/socialLinks.ts
+++ b/src/shared/constants/socialLinks.ts
@@ -1,0 +1,50 @@
+export const SOCIAL_LINK_KEYS = [
+    'facebook',
+    'instagram',
+    'x',
+    'linkedin',
+    'youtube',
+    'tiktok',
+    'snapchat',
+    'whatsapp',
+    'telegram',
+    'signal',
+    'viber',
+    'wechat',
+    'line',
+    'discord',
+    'skype',
+    'reddit',
+    'bale',
+    'eitaa',
+    'rubika',
+    'soroush',
+    'igap',
+    'gap',
+    'bisphone',
+    'wispi',
+] as const
+
+export type SocialLinkKey = (typeof SOCIAL_LINK_KEYS)[number]
+
+const ALIAS_MAP: Record<string, SocialLinkKey> = {
+    twitter: 'x',
+}
+
+const SOCIAL_KEY_SET = new Set<string>(SOCIAL_LINK_KEYS)
+
+export function normalizeSocialLinkKey(key: string | null | undefined): SocialLinkKey | undefined {
+    if (!key) return undefined
+    const normalized = key.trim().toLowerCase()
+    if (!normalized) return undefined
+
+    if (ALIAS_MAP[normalized]) {
+        return ALIAS_MAP[normalized]
+    }
+
+    return SOCIAL_KEY_SET.has(normalized) ? (normalized as SocialLinkKey) : undefined
+}
+
+export function isSupportedSocialLinkKey(key: string): key is SocialLinkKey {
+    return SOCIAL_KEY_SET.has(key)
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -158,8 +158,8 @@
   "brands.form.social.telegram_ph": "https://t.me/brand",
   "brands.form.social.linkedin": "LinkedIn",
   "brands.form.social.linkedin_ph": "https://linkedin.com/company/brand",
-  "brands.form.social.twitter": "Twitter",
-  "brands.form.social.twitter_ph": "https://twitter.com/brand",
+  "brands.form.social.x": "X (Twitter)",
+  "brands.form.social.x_ph": "https://x.com/brand",
   "brands.form.logo": "Logo",
   "brands.form.logo_help": "Upload the brand logo (recommended square format)",
 

--- a/src/shared/i18n/locales/fa.json
+++ b/src/shared/i18n/locales/fa.json
@@ -158,8 +158,8 @@
   "brands.form.social.telegram_ph": "https://t.me/brand",
   "brands.form.social.linkedin": "لینکدین",
   "brands.form.social.linkedin_ph": "https://linkedin.com/company/brand",
-  "brands.form.social.twitter": "توئیتر",
-  "brands.form.social.twitter_ph": "https://twitter.com/brand",
+  "brands.form.social.x": "ایکس (توییتر)",
+  "brands.form.social.x_ph": "https://x.com/brand",
   "brands.form.logo": "لوگو",
   "brands.form.logo_help": "لوگوی برند را بارگذاری کنید (ترجیحاً مربع باشد)",
 

--- a/src/shared/utils/localized.ts
+++ b/src/shared/utils/localized.ts
@@ -1,4 +1,6 @@
 import type { Locale } from '@/shared/i18n/messages'
+import { normalizeSocialLinkKey } from '@/shared/constants/socialLinks'
+import type { SocialLinkKey } from '@/shared/constants/socialLinks'
 
 export type LocalizedValue = Record<string, string | null | undefined>
 
@@ -44,19 +46,28 @@ export function cleanLocalizedField(
 }
 
 export function cleanSocialLinks(
-    links?: LocalizedValue,
-): Record<string, string> | undefined {
+    links?: Record<string, string | null | undefined>,
+): Partial<Record<SocialLinkKey, string>> | undefined {
     if (!links) return undefined
 
-    const result: Record<string, string> = {}
-    Object.entries(links).forEach(([key, value]) => {
-        const trimmed = value?.trim()
-        if (trimmed) {
-            result[key] = trimmed
-        }
+    const result: Partial<Record<SocialLinkKey, string>> = {}
+    let hasValue = false
+
+    Object.entries(links).forEach(([rawKey, value]) => {
+        const normalizedRawKey = rawKey.trim().toLowerCase()
+        const key = normalizeSocialLinkKey(normalizedRawKey)
+        if (!key) return
+
+        const trimmed = value?.trim?.()
+        if (!trimmed) return
+
+        if (result[key] && normalizedRawKey !== key) return
+
+        result[key] = trimmed
+        hasValue = true
     })
 
-    return Object.keys(result).length > 0 ? result : undefined
+    return hasValue ? result : undefined
 }
 
 export function ensureLocalizedDefaults(


### PR DESCRIPTION
## Summary
- add centralized social link key definitions and normalization helpers for the updated brand API
- update brand forms, types, and translations to use the X social link key and sanitized payloads when persisting brands
- extend API metadata typing to capture the new response fields returned by the catalog service

## Testing
- npm install *(fails: Invalid tag name "^.39.0" for typescript-eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c5e722e88323b7e2aa79dc76402e