### PR TITLE
Refactor API route builders and configuration defaults

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -18,7 +18,7 @@ import {
 import { emitForcedLogout, emitTokenRefreshed } from "@/features/auth/lib/auth-events"
 import { buildRefreshRequestPayload } from "@/features/auth/utils/context"
 import { API_CONFIG } from "@/shared/config/api.config"
-import { API_ROUTES, buildFeatureUrl } from "@/shared/constants/apiRoutes" // ⬅️ اضافه شد
+import { API_ROUTES, buildFeatureUrl } from "@/shared/constants/apiRoutes"
 import { defaultLogger } from "@/shared/lib/logger"
 
 type PendingResolver = { resolve: (token: string) => void; reject: (reason?: unknown) => void }

--- a/src/shared/config/api.config.ts
+++ b/src/shared/config/api.config.ts
@@ -11,23 +11,34 @@
  * Development flags only affect logging and do not change behavior.
  */
 
+function normalizeBaseUrl(url: string): string {
+    if (!url) {
+        return ''
+    }
+    return url.replace(/\/+$/, '')
+}
+
+const DEFAULT_BASE_URL = normalizeBaseUrl(
+    import.meta.env.VITE_API_URL || 'http://localhost:3000',
+)
+const DEFAULT_AUTH_URL = normalizeBaseUrl(
+    import.meta.env.VITE_AUTH_API_URL || DEFAULT_BASE_URL,
+)
+const DEFAULT_CATALOG_URL = normalizeBaseUrl(
+    import.meta.env.VITE_CATALOG_API_URL || DEFAULT_BASE_URL,
+)
+
 export const API_CONFIG = {
     // Main API URL (fallback for backward compatibility)
-    BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:3000',
+    BASE_URL: DEFAULT_BASE_URL,
 
     // Feature-specific API URLs
     AUTH: {
-        BASE_URL:
-            import.meta.env.VITE_AUTH_API_URL ||
-            import.meta.env.VITE_API_URL ||
-            'http://192.168.0.101:8083',
+        BASE_URL: DEFAULT_AUTH_URL,
     },
 
     CATALOG: {
-        BASE_URL:
-            import.meta.env.VITE_CATALOG_API_URL ||
-            import.meta.env.VITE_API_URL ||
-            'http://localhost:3000',
+        BASE_URL: DEFAULT_CATALOG_URL,
     },
 
     // MSW configuration
@@ -43,3 +54,5 @@ export const API_CONFIG = {
 } as const
 
 export type ApiConfig = typeof API_CONFIG
+
+export { normalizeBaseUrl }


### PR DESCRIPTION
## Summary
- normalize API base URLs and expose helpers to reuse resolved defaults
- centralize API route construction with segment joiners to remove hard-coded paths
- clean axios import to align with updated route utilities

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d911ae78108323b403f58c50cd4303