### PR TITLE
Remove deprecated auth endpoints and update session logout

### DIFF
--- a/src/features/auth/hooks/auth.queries.ts
+++ b/src/features/auth/hooks/auth.queries.ts
@@ -1,125 +1,22 @@
 // features/auth/hooks/auth.queries.ts
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 
 import { defaultLogger } from '@/shared/lib/logger'
 
-import { apiForgotPassword, apiLogin, apiLogout, apiMe, apiRegister } from '../services/auth.api'
-import { clearAuthStorage, getAccessToken } from '../storage'
-
-// Query keys
-export const authQueryKeys = {
-    all: ['auth'] as const,
-    user: () => [...authQueryKeys.all, 'user'] as const,
-    profile: () => [...authQueryKeys.all, 'profile'] as const,
-} as const
+import { apiLogin } from '../services/auth.api'
 
 // Login mutation
 export function useLogin() {
-    const queryClient = useQueryClient()
     const logger = defaultLogger.withContext({ component: 'auth.queries', action: 'useLogin' })
 
     return useMutation({
         mutationFn: ({ username, password }: { username: string; password: string }) =>
             apiLogin(username, password),
-        onSuccess: (data) => {
-            logger.info('Login successful, updating auth state')
-            // Invalidate and refetch user data
-            queryClient.invalidateQueries({ queryKey: authQueryKeys.user() })
-            queryClient.invalidateQueries({ queryKey: authQueryKeys.profile() })
+        onSuccess: () => {
+            logger.info('Login successful')
         },
         onError: (error) => {
             logger.error('Login failed', { error })
         },
     })
-}
-
-// Logout mutation
-export function useLogout() {
-    const queryClient = useQueryClient()
-    const logger = defaultLogger.withContext({ component: 'auth.queries', action: 'useLogout' })
-
-    return useMutation({
-        mutationFn: apiLogout,
-        onSuccess: () => {
-            logger.info('Logout successful, clearing auth state')
-            clearAuthStorage()
-            // Clear all queries
-            queryClient.clear()
-        },
-        onError: (error) => {
-            logger.error('Logout failed', { error })
-            // Still clear local storage on error
-            clearAuthStorage()
-            queryClient.clear()
-        },
-    })
-}
-
-// User profile query
-export function useUserProfile() {
-    const token = getAccessToken()
-
-    return useQuery({
-        queryKey: authQueryKeys.profile(),
-        queryFn: () => apiMe(token!),
-        enabled: !!token,
-        staleTime: 5 * 60 * 1000, // 5 minutes
-        gcTime: 10 * 60 * 1000, // 10 minutes
-    })
-}
-
-// Registration mutation
-export function useRegister() {
-    const queryClient = useQueryClient()
-    const logger = defaultLogger.withContext({ component: 'auth.queries', action: 'useRegister' })
-
-    return useMutation({
-        mutationFn: (userData: {
-            username: string
-            email: string
-            password: string
-            firstName?: string
-            lastName?: string
-        }) => apiRegister(userData),
-        onSuccess: (data) => {
-            logger.info('Registration successful')
-            // Could automatically log in the user here
-        },
-        onError: (error) => {
-            logger.error('Registration failed', { error })
-        },
-    })
-}
-
-// Forgot password mutation
-export function useForgotPassword() {
-    const logger = defaultLogger.withContext({
-        component: 'auth.queries',
-        action: 'useForgotPassword',
-    })
-
-    return useMutation({
-        mutationFn: (email: string) => apiForgotPassword(email),
-        onSuccess: (data) => {
-            logger.info('Password reset request successful')
-        },
-        onError: (error) => {
-            logger.error('Password reset request failed', { error })
-        },
-    })
-}
-
-// Auth state hook
-export function useAuth() {
-    const { data: user, isLoading, error } = useUserProfile()
-    const logoutMutation = useLogout()
-
-    return {
-        user,
-        isLoading,
-        error,
-        isAuthenticated: !!user,
-        logout: logoutMutation.mutate,
-        isLoggingOut: logoutMutation.isPending,
-    }
 }

--- a/src/features/auth/lib/auth-events.ts
+++ b/src/features/auth/lib/auth-events.ts
@@ -3,7 +3,7 @@ import { defaultLogger } from '@/shared/lib/logger'
 
 export type AuthEventMap = {
     logout: { reason?: string; redirect?: boolean } | undefined
-    tokenRefreshed: { accessToken: string; refreshToken: string }
+    tokenRefreshed: { accessToken: string; refreshToken: string; sessionId?: string | null }
 }
 
 type Listener<K extends keyof AuthEventMap> = (payload: AuthEventMap[K]) => void

--- a/src/features/auth/storage.ts
+++ b/src/features/auth/storage.ts
@@ -3,6 +3,7 @@ export const LS_KEYS = {
     ACCESS_TOKEN: 'auth.accessToken',
     REFRESH_TOKEN: 'auth.refreshToken',
     USER: 'auth.user',
+    SESSION_ID: 'auth.sessionId',
 } as const
 
 export function getAccessToken(): string | null {
@@ -21,6 +22,22 @@ export function setTokens(accessToken: string, refreshToken: string): void {
 export function clearTokens(): void {
     localStorage.removeItem(LS_KEYS.ACCESS_TOKEN)
     localStorage.removeItem(LS_KEYS.REFRESH_TOKEN)
+}
+
+export function getSessionId(): string | null {
+    return localStorage.getItem(LS_KEYS.SESSION_ID)
+}
+
+export function setSessionId(sessionId: string | null): void {
+    if (sessionId) {
+        localStorage.setItem(LS_KEYS.SESSION_ID, sessionId)
+    } else {
+        localStorage.removeItem(LS_KEYS.SESSION_ID)
+    }
+}
+
+export function clearSessionId(): void {
+    localStorage.removeItem(LS_KEYS.SESSION_ID)
 }
 
 export function getCachedUser<T = unknown>(): T | null {
@@ -44,4 +61,5 @@ export function clearCachedUser(): void {
 export function clearAuthStorage(): void {
     clearTokens()
     clearCachedUser()
+    clearSessionId()
 }

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -17,12 +17,14 @@ export type AuthLoginResult = {
     tokenType: string
     audience: string[]
     user: AuthUser
+    sessionId: string | null
 }
 
 export type AuthCtx = {
     user: AuthUser | null
     accessToken: string | null
     refreshToken: string | null
+    sessionId: string | null
     isAuthenticated: boolean
     ready: boolean
     login: (params: { username: string; password: string }) => Promise<void> // eslint-disable-line no-unused-vars

--- a/src/shared/api/useCrudQueries.ts
+++ b/src/shared/api/useCrudQueries.ts
@@ -25,6 +25,8 @@ export function createCrudHooks<
             useQuery<ApiResponse<TData[]>, AxiosError<ApiResponse<unknown>>>({
                 queryKey: [key, 'list', params ? JSON.stringify(params) : undefined],
                 queryFn: () => api.list(params),
+                staleTime: 5 * 60 * 1000,
+                gcTime: 10 * 60 * 1000,
             }),
 
         /**

--- a/src/shared/constants/apiRoutes.ts
+++ b/src/shared/constants/apiRoutes.ts
@@ -17,7 +17,6 @@ function joinSegments(...segments: (string | number)[]): string {
 
 const API_V1 = joinSegments('api', 'v1')
 const ADMIN_AUTH = joinSegments(API_V1, 'admin', 'auth')
-const AUTH_ROOT = joinSegments('auth')
 const FILES_ROOT = joinSegments('files')
 const BRANDS_ROOT = joinSegments(API_V1, 'brands')
 const CATEGORIES_ROOT = joinSegments(API_V1, 'categories')
@@ -27,13 +26,7 @@ const SESSIONS_ROOT = joinSegments(API_V1, 'sessions')
 export const API_ROUTES = {
     AUTH: {
         LOGIN: joinSegments(ADMIN_AUTH, 'login'),
-        LOGOUT: joinSegments('api', 'users', 'logout'),
-        ME: joinSegments(AUTH_ROOT, 'me'),
         REFRESH: joinSegments(API_V1, 'auth', 'refresh'),
-        REGISTER: joinSegments(AUTH_ROOT, 'register'),
-        FORGOT_PASSWORD: joinSegments(AUTH_ROOT, 'forgot-password'),
-        RESET_PASSWORD: joinSegments(AUTH_ROOT, 'reset-password'),
-        VERIFY_EMAIL: joinSegments(AUTH_ROOT, 'verify-email'),
     },
 
     FILES: {
@@ -57,7 +50,7 @@ export const API_ROUTES = {
         CURRENT: joinSegments(SESSIONS_ROOT, 'current'),
         ME_ALL: joinSegments(SESSIONS_ROOT, 'me', 'all'),
         ME_OTHERS: joinSegments(SESSIONS_ROOT, 'me', 'others'),
-        BY_ID: (sessionId: string) => joinSegments(SESSIONS_ROOT, sessionId),
+        BY_ID: (sessionId: string) => joinSegments(SESSIONS_ROOT, 'me', sessionId),
     },
 } as const
 


### PR DESCRIPTION
## Summary
- remove deprecated auth API route entries and eliminate unused auth service hooks
- add session-aware logout, persist the session identifier, and propagate it through the auth context and axios refresh flow
- introduce React Query stale time for CRUD list hooks to reduce repeat category fetches

## Testing
- npm run lint *(fails: missing @eslint/js in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d916cfe04c8323b2953db2beb8af0a