### PR TITLE
Prevent duplicate root category load

### DIFF
--- a/src/features/categories/components/useNestedCategories.ts
+++ b/src/features/categories/components/useNestedCategories.ts
@@ -104,6 +104,8 @@ export function useNestedCategories(onAddRoot?: () => void, onCountChange?: (cou
         [fetchAllCategories, toNode],
     )
 
+    const hasLoadedRef = React.useRef(false)
+
     const loadRoot = React.useCallback(async () => {
         setLoadingRoot(true)
         try {
@@ -117,6 +119,8 @@ export function useNestedCategories(onAddRoot?: () => void, onCountChange?: (cou
     }, [loadChildren, t])
 
     React.useEffect(() => {
+        if (hasLoadedRef.current) return
+        hasLoadedRef.current = true
         loadRoot()
     }, [loadRoot])
 


### PR DESCRIPTION
## Summary
- add a ref guard around the initial root category load to avoid duplicate API calls

## Testing
- npm run build *(fails: missing type definition packages because dependencies cannot be installed due to invalid tag name in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d91b961860832393686976876c3cfc