### PR TITLE
Add category reorder API route constants

### DIFF
--- a/src/shared/constants/apiRoutes.ts
+++ b/src/shared/constants/apiRoutes.ts
@@ -42,6 +42,8 @@ export const API_ROUTES = {
         ROOT: CATEGORIES_ROOT,
         BY_ID: (id: string | number) => joinSegments(CATEGORIES_ROOT, id),
         BY_SLUG: (slug: string) => joinSegments(CATEGORIES_ROOT, 'slug', slug),
+        REORDER_BULK: joinSegments(CATEGORIES_ROOT, 'reorder'),
+        REORDER_SINGLE: (id: string | number) => joinSegments(CATEGORIES_ROOT, id, 'reorder'),
     },
     PRODUCTS: {
         ROOT: PRODUCTS_ROOT,


### PR DESCRIPTION
## Summary
- add category reorder endpoints to the API routes constants so they can be reused downstream

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6a675b60832380d0a674a101edf9