### PR TITLE
Add category reordering API helpers

### DIFF
--- a/src/features/categories/model/types.ts
+++ b/src/features/categories/model/types.ts
@@ -49,3 +49,10 @@ export interface CategoryFormValues {
 
 export type CategoryResponse = ApiResponse<CategoryData>
 export type CategoryListResponse = ApiResponse<CategoryData[]>
+
+export interface ReorderCategoryItem {
+    id: UUID
+    sort_index: number
+}
+
+export type ReorderCategories = ReorderCategoryItem[]

--- a/src/features/categories/services/categories.api.ts
+++ b/src/features/categories/services/categories.api.ts
@@ -5,6 +5,8 @@ import type {
     CategoryListResponse,
     CategoryResponse,
     CreateCategoryRequest,
+    ReorderCategories,
+    ReorderCategoryItem,
     UpdateCategoryRequest,
     UUID,
 } from '@/features/categories/model/types'
@@ -31,6 +33,14 @@ export const categoriesApiService = {
 
     update(id: UUID, payload: UpdateCategoryRequest) {
         return catalogClient.put<CategoryResponse>(API_ROUTES.CATEGORIES.BY_ID(id), payload)
+    },
+
+    reorderOne(id: UUID, payload: ReorderCategoryItem) {
+        return catalogClient.put<void>(API_ROUTES.CATEGORIES.REORDER_SINGLE(id), payload)
+    },
+
+    reorderMany(payload: ReorderCategories) {
+        return catalogClient.put<void>(API_ROUTES.CATEGORIES.REORDER_BULK, payload)
     },
 
     remove(id: UUID) {


### PR DESCRIPTION
## Summary
- add shared types describing category reorder payloads
- expose API helpers for single and bulk category reordering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6b4f2ef883238f35ca17b4f522c6