### PR TITLE
Update category update request headers

### DIFF
--- a/src/features/categories/components/NestedDraggableList.tsx
+++ b/src/features/categories/components/NestedDraggableList.tsx
@@ -133,10 +133,18 @@ export default function NestedDraggableList({
                     const payload = buildReorderPayload(plan.targetSiblings)
                     await categoriesApiService.reorderMany(payload)
                 } else {
-                    await categoriesApiService.update(params.sourceId, {
-                        parent_id: params.toParentId,
-                        sort_index: plan.targetSiblings.findIndex((node) => node.id === params.sourceId),
-                    })
+                    await categoriesApiService.update(
+                        params.sourceId,
+                        {
+                            parent_id: params.toParentId,
+                            sort_index: plan.targetSiblings.findIndex((node) => node.id === params.sourceId),
+                        },
+                        {
+                            headers: {
+                                "X-Category-Id": params.sourceId,
+                            },
+                        },
+                    )
                     const payload = buildReorderPayload(plan.sourceSiblings, plan.targetSiblings)
                     if (payload.length > 0) {
                         await categoriesApiService.reorderMany(payload)

--- a/src/features/categories/services/categories.api.ts
+++ b/src/features/categories/services/categories.api.ts
@@ -31,8 +31,16 @@ export const categoriesApiService = {
         return catalogClient.post<CategoryResponse>(API_ROUTES.CATEGORIES.ROOT, payload)
     },
 
-    update(id: UUID, payload: UpdateCategoryRequest) {
-        return catalogClient.put<CategoryResponse>(API_ROUTES.CATEGORIES.BY_ID(id), payload)
+    update(id: UUID, payload: UpdateCategoryRequest, config?: Parameters<typeof catalogClient.patch>[2]) {
+        const mergedConfig = {
+            ...(config ?? {}),
+            headers: {
+                ...(config?.headers ?? {}),
+                "X-Category-Id": id,
+            },
+        }
+
+        return catalogClient.patch<CategoryResponse>(API_ROUTES.CATEGORIES.BY_ID(id), payload, mergedConfig)
     },
 
     reorderOne(id: UUID, payload: ReorderCategoryItem) {


### PR DESCRIPTION
## Summary
- switch the category update API call to use PATCH and include the X-Category-Id header
- ensure cross-parent drag-and-drop updates send the required header configuration

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68da8148f334832395e2a83e3796abfc